### PR TITLE
Path operations in GBZ

### DIFF
--- a/src/bwt/tests.rs
+++ b/src/bwt/tests.rs
@@ -7,16 +7,16 @@ use std::collections::HashSet;
 //-----------------------------------------------------------------------------
 
 // GBWT example from the paper: (edges, runs, invalid_node)
-fn get_edges_runs() -> (Vec<Vec<(usize, usize)>>, Vec<Vec<Run>>, usize) {
+fn get_edges_runs() -> (Vec<Vec<Pos>>, Vec<Vec<Run>>, usize) {
     let edges = vec![
-        vec![(1, 0)],
-        vec![(2, 0), (3, 0)],
-        vec![(4, 0), (5, 0)],
-        vec![(4, 1)],
-        vec![(5, 1), (6, 0)],
-        vec![(7, 0)],
-        vec![(7, 2)],
-        vec![(0, 0)],
+        vec![Pos::new(1, 0)],
+        vec![Pos::new(2, 0), Pos::new(3, 0)],
+        vec![Pos::new(4, 0), Pos::new(5, 0)],
+        vec![Pos::new(4, 1)],
+        vec![Pos::new(5, 1), Pos::new(6, 0)],
+        vec![Pos::new(7, 0)],
+        vec![Pos::new(7, 2)],
+        vec![Pos::new(0, 0)],
     ];
     let runs = vec![
         vec![Run::new(0, 3)],
@@ -32,31 +32,31 @@ fn get_edges_runs() -> (Vec<Vec<(usize, usize)>>, Vec<Vec<Run>>, usize) {
 }
 
 // Bidirectional version of the example: (edges, runs, invalid_node)
-fn get_bidirectional() -> (Vec<Vec<(usize, usize)>>, Vec<Vec<Run>>, usize) {
+fn get_bidirectional() -> (Vec<Vec<Pos>>, Vec<Vec<Run>>, usize) {
     let edges = vec![
         // ENDMARKER
-        vec![(2, 0), (15, 0)],
+        vec![Pos::new(2, 0), Pos::new(15, 0)],
         // 1
-        vec![(4, 0), (6, 0)],
-        vec![(0, 0)],
+        vec![Pos::new(4, 0), Pos::new(6, 0)],
+        vec![Pos::new(0, 0)],
         // 2
-        vec![(8, 0), (10, 0)],
-        vec![(3, 0)],
+        vec![Pos::new(8, 0), Pos::new(10, 0)],
+        vec![Pos::new(3, 0)],
         // 3
-        vec![(8, 1)],
-        vec![(3, 2)],
+        vec![Pos::new(8, 1)],
+        vec![Pos::new(3, 2)],
         // 4
-        vec![(10, 1), (12, 0)],
-        vec![(5, 0), (7, 0)],
+        vec![Pos::new(10, 1), Pos::new(12, 0)],
+        vec![Pos::new(5, 0), Pos::new(7, 0)],
         // 5
-        vec![(14, 0)],
-        vec![(5, 1), (9, 0)],
+        vec![Pos::new(14, 0)],
+        vec![Pos::new(5, 1), Pos::new(9, 0)],
         // 6
-        vec![(14, 2)],
-        vec![(9, 1)],
+        vec![Pos::new(14, 2)],
+        vec![Pos::new(9, 1)],
         // 7
-        vec![(0, 0)],
-        vec![(11, 0), (13, 0)],
+        vec![Pos::new(0, 0)],
+        vec![Pos::new(11, 0), Pos::new(13, 0)],
     ];
     let runs = vec![
         // ENDMARKER
@@ -86,7 +86,7 @@ fn get_bidirectional() -> (Vec<Vec<(usize, usize)>>, Vec<Vec<Run>>, usize) {
     (edges, runs, 16)
 }
 
-fn create_bwt(edges: &[Vec<(usize, usize)>], runs: &[Vec<Run>]) -> BWT {
+fn create_bwt(edges: &[Vec<Pos>], runs: &[Vec<Run>]) -> BWT {
     let mut builder = BWTBuilder::new();
     assert_eq!(builder.len(), 0, "Newly created builder has non-zero length");
     assert!(builder.is_empty(), "Newly created builder is not empty");
@@ -102,7 +102,7 @@ fn create_bwt(edges: &[Vec<(usize, usize)>], runs: &[Vec<Run>]) -> BWT {
 
 // Check records in the BWT, using the provided edges as the source of truth.
 // Also checks that `id()` works correctly.
-fn check_records(bwt: &BWT, edges: &[Vec<(usize, usize)>]) {
+fn check_records(bwt: &BWT, edges: &[Vec<Pos>]) {
     assert_eq!(bwt.len(), edges.len(), "Invalid number of records in the BWT");
     assert_eq!(bwt.is_empty(), edges.is_empty(), "Invalid BWT emptiness");
 
@@ -115,8 +115,8 @@ fn check_records(bwt: &BWT, edges: &[Vec<(usize, usize)>]) {
             assert_eq!(record.id(), i, "Invalid id for record {}", i);
             assert_eq!(record.outdegree(), curr_edges.len(), "Invalid outdegree in record {}", i);
             for j in 0..record.outdegree() {
-                assert_eq!(record.successor(j), curr_edges[j].0, "Invalid successor {} in record {}", j, i);
-                assert_eq!(record.offset(j), curr_edges[j].1, "Invalid offset {} in record {}", j, i);
+                assert_eq!(record.successor(j), curr_edges[j].node, "Invalid successor {} in record {}", j, i);
+                assert_eq!(record.offset(j), curr_edges[j].offset, "Invalid offset {} in record {}", j, i);
             }
         }
     }
@@ -143,7 +143,7 @@ fn check_iter(bwt: &BWT) {
 // Check all `lf()` results in the BWT, using the provided edges and runs as the source of truth.
 // Then check that decompressing the record works correctly.
 // Also checks that `offset_to()` works in positive cases and that `len()` is correct.
-fn check_lf(bwt: &BWT, edges: &[Vec<(usize, usize)>], runs: &[Vec<Run>]) {
+fn check_lf(bwt: &BWT, edges: &[Vec<Pos>], runs: &[Vec<Run>]) {
     // `lf()` at each offset of each record.
     for i in 0..bwt.len() {
         if let Some(record) = bwt.record(i) {
@@ -155,13 +155,13 @@ fn check_lf(bwt: &BWT, edges: &[Vec<(usize, usize)>], runs: &[Vec<Run>]) {
             for run in curr_runs {
                 for _ in 0..run.len {
                     let edge = curr_edges[run.value];
-                    let expected = if edge.0 == ENDMARKER { None } else { Some(edge) };
+                    let expected = if edge.node == ENDMARKER { None } else { Some(edge) };
                     assert_eq!(record.lf(offset), expected, "Invalid lf({}) in record {}", offset, i);
                     assert_eq!(decompressed[offset], edge, "Invalid decompressed lf({}) in record {}", offset, i);
-                    let expected = if edge.0 == ENDMARKER { None } else { Some(offset) };
-                    assert_eq!(record.offset_to(edge), expected, "Invalid offset_to(({}, {})) in record {}", edge.0, edge.1, i);
+                    let expected = if edge.node == ENDMARKER { None } else { Some(offset) };
+                    assert_eq!(record.offset_to(edge), expected, "Invalid offset_to(({}, {})) in record {}", edge.node, edge.offset, i);
                     offset += 1;
-                    curr_edges[run.value].1 += 1;
+                    curr_edges[run.value].offset += 1;
                 }
             }
             assert_eq!(record.len(), offset, "Invalid record {} length", i);
@@ -193,8 +193,8 @@ fn check_follow(bwt: &BWT, invalid_node: usize) {
                     if let Some(result) = record.follow(start..limit, successor) {
                         let mut found = result.start..result.start;
                         for j in start..limit {
-                            if let Some((node, offset)) = record.lf(j) {
-                                if node == successor && offset == found.end {
+                            if let Some(pos) = record.lf(j) {
+                                if pos.node == successor && pos.offset == found.end {
                                     found.end += 1;
                                 }
                             }
@@ -207,8 +207,8 @@ fn check_follow(bwt: &BWT, invalid_node: usize) {
                         }
                     } else {
                         for j in start..limit {
-                            if let Some((node, _)) = record.lf(j) {
-                                assert_ne!(node, successor, "follow({}..{}, {}) did not follow offset {} in record {}", start, limit, successor, j, i);
+                            if let Some(pos) = record.lf(j) {
+                                assert_ne!(pos.node, successor, "follow({}..{}, {}) did not follow offset {} in record {}", start, limit, successor, j, i);
                             }
                             assert_eq!(record.bd_follow(start..limit, successor), None, "Got a bd_follow({}..{}, {}) result in record {}", start, limit, successor, i);
                         }
@@ -226,8 +226,8 @@ fn check_follow(bwt: &BWT, invalid_node: usize) {
 // Check negative cases for `offset_to()`.
 fn negative_offset_to(bwt: &BWT, invalid_node: usize) {
     for record in bwt.iter() {
-        assert_eq!(record.offset_to((ENDMARKER, 0)), None, "Got an offset to the endmarker from record {}", record.id());
-        assert_eq!(record.offset_to((invalid_node, 0)), None, "Got an offset to an invalid node from record {}", record.id());
+        assert_eq!(record.offset_to(Pos::new(ENDMARKER, 0)), None, "Got an offset to the endmarker from record {}", record.id());
+        assert_eq!(record.offset_to(Pos::new(invalid_node, 0)), None, "Got an offset to an invalid node from record {}", record.id());
         for rank in 0..record.outdegree() {
             let successor = record.successor(rank);
             if successor == ENDMARKER {
@@ -235,10 +235,10 @@ fn negative_offset_to(bwt: &BWT, invalid_node: usize) {
             }
             let offset = record.offset(rank);
             if offset > 0 {
-                assert_eq!(record.offset_to((successor, offset - 1)), None, "Got an offset from record {} to a too small position in {}", record.id(), successor);
+                assert_eq!(record.offset_to(Pos::new(successor, offset - 1)), None, "Got an offset from record {} to a too small position in {}", record.id(), successor);
             }
             let count = record.follow(0..record.len(), successor).unwrap().len();
-            assert_eq!(record.offset_to((successor, offset + count)), None, "Got an offset from record {} to a too large position in {}", record.id(), successor);
+            assert_eq!(record.offset_to(Pos::new(successor, offset + count)), None, "Got an offset from record {} to a too large position in {}", record.id(), successor);
         }
     }
 }
@@ -246,7 +246,7 @@ fn negative_offset_to(bwt: &BWT, invalid_node: usize) {
 // Check that we can find predecessors for all positions except starting positions.
 // The tests for `GBWT::backward()` will make sure that the predecessors are correct.
 fn check_predecessor_at(bwt: &BWT) {
-    let mut starting_positions = HashSet::<(usize, usize)>::new();
+    let mut starting_positions = HashSet::<Pos>::new();
     let endmarker = bwt.record(ENDMARKER).unwrap();
     for i in 0..endmarker.len() {
         starting_positions.insert(endmarker.lf(i).unwrap());
@@ -259,7 +259,7 @@ fn check_predecessor_at(bwt: &BWT) {
         let reverse_id = ((record.id() + 1) ^ 1) - 1; // Record to node, flip, node to record.
         let reverse_record = bwt.record(reverse_id).unwrap();
         for i in 0..record.len() {
-            if starting_positions.contains(&(record.id() + 1, i)) {
+            if starting_positions.contains(&Pos::new(record.id() + 1, i)) {
                 assert!(reverse_record.predecessor_at(i).is_none(), "Found a predecessor for a starting position ({}, {})", record.id() + 1, i);
             } else {
                 assert!(reverse_record.predecessor_at(i).is_some(), "Did not find a predecessor for position ({}, {})", record.id() + 1, i);

--- a/src/gbwt.rs
+++ b/src/gbwt.rs
@@ -232,17 +232,14 @@ impl GBWT {
         if pos.0 <= self.first_node() {
             return None;
         }
+
         let reverse_id = self.node_to_record(support::flip_node(pos.0));
-        if let Some(record) = self.bwt.record(reverse_id) {
-            if let Some(predecessor) = record.predecessor_at(pos.1) {
-                if let Some(pred_record) = self.bwt.record(self.node_to_record(predecessor)) {
-                    if let Some(offset) = pred_record.offset_to(pos) {
-                        return Some((predecessor, offset));
-                    }
-                }
-            }
-        }
-        None
+        let record = self.bwt.record(reverse_id)?;
+        let predecessor = record.predecessor_at(pos.1)?;
+        let pred_record = self.bwt.record(self.node_to_record(predecessor))?;
+        let offset = pred_record.offset_to(pos)?;
+
+        Some((predecessor, offset))
     }
 
     /// Returns an iterator over sequence `id`, or [`None`] if there is no such sequence.

--- a/src/gbwt.rs
+++ b/src/gbwt.rs
@@ -245,14 +245,13 @@ impl GBWT {
         None
     }
 
-    /// Returns an iterator over sequence `id`.
-    ///
-    /// The iterator will be empty if no such sequence exists.
-    pub fn sequence(&self, id: usize) -> SequenceIter {
-        SequenceIter {
+    /// Returns an iterator over sequence `id`, or [`None`] if there is no such sequence.
+    pub fn sequence(&self, id: usize) -> Option<SequenceIter> {
+        let start = self.start(id)?;
+        Some(SequenceIter {
             parent: self,
-            next: self.start(id),
-        }
+            next: Some(start),
+        })
     }
 }
 
@@ -541,7 +540,7 @@ impl BidirectionalState {
 /// let index: GBWT = serialize::load_from(&filename).unwrap();
 ///
 /// // Extract path 3 in reverse orientation.
-/// let path: Vec<usize> = index.sequence(support::encode_path(3, Orientation::Reverse)).collect();
+/// let path: Vec<usize> = index.sequence(support::encode_path(3, Orientation::Reverse)).unwrap().collect();
 /// assert_eq!(path, vec![35, 33, 29, 27, 23]);
 /// ```
 #[derive(Clone, Debug)]

--- a/src/gbwt/tests.rs
+++ b/src/gbwt/tests.rs
@@ -178,9 +178,12 @@ fn sequence() {
 
     for i in 0..index.sequences() {
         let extracted = extract_sequence(&index, i);
-        let iterated: Vec<usize> = index.sequence(i).collect();
+        let iter = index.sequence(i);
+        assert!(iter.is_some(), "Could not get an iterator for sequence {}", i);
+        let iterated: Vec<usize> = iter.unwrap().collect();
         assert_eq!(iterated, extracted, "Invalid sequence {} from an iterator", i);
     }
+    assert!(index.sequence(index.sequences()).is_none(), "Got an iterator for a past-the-end sequence id");
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gbwt/tests.rs
+++ b/src/gbwt/tests.rs
@@ -68,7 +68,7 @@ fn extract_sequence(index: &GBWT, id: usize) -> Vec<usize> {
     let mut result = Vec::new();
     let mut pos = index.start(id);
     while pos != None {
-        result.push(pos.unwrap().0);
+        result.push(pos.unwrap().node);
         pos = index.forward(pos.unwrap());
     }
     result
@@ -85,7 +85,7 @@ fn extract_backward(index: &GBWT, id: usize) -> Vec<usize> {
     let mut result = Vec::new();
     pos = last;
     while pos != None {
-        result.push(pos.unwrap().0);
+        result.push(pos.unwrap().node);
         pos = index.backward(pos.unwrap());
     }
 

--- a/src/gbz.rs
+++ b/src/gbz.rs
@@ -335,7 +335,7 @@ impl GBZ {
 
 //-----------------------------------------------------------------------------
 
-// FIXME follow_forward, follow_backward
+// FIXME follow_forward, follow_backward using EdgeIter and a separate implementation of bidirectional search
 /// Paths.
 impl GBZ {
     /// Returns the number of paths in the original graph.

--- a/src/gbz/tests.rs
+++ b/src/gbz/tests.rs
@@ -107,14 +107,18 @@ fn check_states(gbz: &GBZ) {
     let mut visited: HashSet<BidirectionalState> = HashSet::new();
 
     // Start from every node in every orientation.
-    for node_id in gbz.node_iter() {
+    for node_id in 0..gbz.max_node() + 2 {
         for orientation in [Orientation::Forward, Orientation::Reverse] {
-            let truth = gbz.index.bd_find(support::encode_node(node_id, orientation));
             let state = gbz.search_state(node_id, orientation);
-            assert_eq!(state, truth, "Invalid search state for node {} {}", node_id, name(orientation));
-            if let Some(state) = state {
-                stack.push(state.clone());
-                visited.insert(state);
+            if gbz.has_node(node_id) {
+                let truth = gbz.index.bd_find(support::encode_node(node_id, orientation));
+                assert_eq!(state, truth, "Invalid search state for node {} {}", node_id, name(orientation));
+                if let Some(state) = state {
+                    stack.push(state.clone());
+                    visited.insert(state);
+                }
+            } else {
+                assert!(state.is_none(), "Got a search state for nonexistent node {} {}", node_id, name(orientation));
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod graph;
 pub mod headers;
 pub mod support;
 
+pub use crate::bwt::Pos;
 pub use crate::gbwt::{GBWT, SearchState, BidirectionalState, Metadata, PathName};
 pub use crate::gbz::GBZ;
 pub use crate::graph::{Graph, Segment};

--- a/src/support.rs
+++ b/src/support.rs
@@ -44,7 +44,7 @@ impl Orientation {
 
 //-----------------------------------------------------------------------------
 
-/// A run as a pair (value, length).
+/// A run as a (value, length) pair.
 #[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Run {
     /// Value in the run.

--- a/src/support.rs
+++ b/src/support.rs
@@ -33,11 +33,41 @@ pub enum Orientation {
 
 impl Orientation {
     /// Returns the other orientation.
+    #[inline]
     pub fn flip(&self) -> Orientation {
         match *self {
             Self::Forward => Self::Reverse,
             Self::Reverse => Self::Forward,
         }
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+/// A run as a pair (value, length).
+#[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Run {
+    /// Value in the run.
+    pub value: usize,
+    /// Length of the run.
+    pub len: usize,
+}
+
+impl Run {
+    /// Creates a new run.
+    #[inline]
+    pub fn new(value: usize, len: usize) -> Self {
+        Run {
+            value: value,
+            len: len,
+        }
+    }
+}
+
+impl From<(usize, usize)> for Run {
+    #[inline]
+    fn from(run: (usize, usize)) -> Self {
+        Self::new(run.0, run.1)
     }
 }
 
@@ -907,10 +937,10 @@ impl<'a> FusedIterator for ByteCodeIter<'a> {}
 /// # Examples
 ///
 /// ```
-/// use gbwt::support::RLE;
+/// use gbwt::support::{Run, RLE};
 ///
 /// let mut encoder = RLE::with_sigma(4);
-/// encoder.write(3, 12); encoder.write(2, 721); encoder.write(0, 34);
+/// encoder.write(Run::new(3, 12)); encoder.write(Run::new(2, 721)); encoder.write(Run::new(0, 34));
 /// assert_eq!(*encoder.as_ref(), [3 + 4 * 11, 2 + 4 * 63, 17 + 128, 5, 0 + 4 * 33]);
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -939,33 +969,33 @@ impl RLE {
         }
     }
 
-    /// Encodes a run of `len` copies of value `value` and stores the encoding.
+    /// Encodes and stores a run.
     ///
-    /// Does nothing if `len == 0`.
+    /// Does nothing if `run.len == 0`.
     ///
     /// # Panics
     ///
-    /// Panics if `value >= self.sigma()`.
-    pub fn write(&mut self, value: usize, len: usize) {
-        if len == 0 {
+    /// Panics if `run.value >= self.sigma()`.
+    pub fn write(&mut self, run: Run) {
+        if run.len == 0 {
             return;
         }
-        assert!(value < self.sigma(), "RLE: Cannot encode value {} with alphabet size {}", value, self.sigma);
-        unsafe { self.write_unchecked(value, len); }
+        assert!(run.value < self.sigma(), "RLE: Cannot encode value {} with alphabet size {}", run.value, self.sigma);
+        unsafe { self.write_unchecked(run); }
     }
 
-    /// Encodes a run of `len` copies of value `value` and stores the encoding.
+    /// Encodes and stores a run.
     ///
-    /// Behavior is undefined if `len == 0` or `value >= self.sigma()`.
-    pub unsafe fn write_unchecked(&mut self, value: usize, len: usize) {
+    /// Behavior is undefined if `run.len == 0` or `run.value >= self.sigma()`.
+    pub unsafe fn write_unchecked(&mut self, run: Run) {
         if self.sigma >= Self::THRESHOLD {
-            self.bytes.write(value);
-            self.bytes.write(len - 1);
-        } else if len < self.threshold {
-            self.write_basic(value, len);
+            self.bytes.write(run.value);
+            self.bytes.write(run.len - 1);
+        } else if run.len < self.threshold {
+            self.write_basic(run.value, run.len);
         } else {
-            self.write_basic(value, self.threshold);
-            self.bytes.write(len - self.threshold);
+            self.write_basic(run.value, self.threshold);
+            self.bytes.write(run.len - self.threshold);
         }
     }
 
@@ -1046,22 +1076,22 @@ impl From<RLE> for Vec<u8> {
 
 /// An iterator that decodes runs from a byte slice encoded by [`RLE`].
 ///
-/// The type of `Item` is `(`[`usize`]`, `[`usize`]`)`.
+/// The type of `Item` is [`Run`].
 /// Alphabet size `sigma == 0` indicates a large alphabet of unknown size.
 /// Raw bytes and [`ByteCode`]-encoded integers can be read from the encoding using [`RLEIter::byte`] and [`RLEIter::int`].
 ///
 /// # Examples
 ///
 /// ```
-/// use gbwt::support::{RLE, RLEIter};
+/// use gbwt::support::{Run, RLE, RLEIter};
 ///
 /// let mut source = RLE::with_sigma(4);
-/// source.write(3, 12); source.write(2, 721); source.write(0, 34);
+/// source.write(Run::new(3, 12)); source.write(Run::new(2, 721)); source.write(Run::new(0, 34));
 ///
 /// let mut iter = RLEIter::with_sigma(source.as_ref(), 4);
-/// assert_eq!(iter.next(), Some((3, 12)));
-/// assert_eq!(iter.next(), Some((2, 721)));
-/// assert_eq!(iter.next(), Some((0, 34)));
+/// assert_eq!(iter.next(), Some(Run::new(3, 12)));
+/// assert_eq!(iter.next(), Some(Run::new(2, 721)));
+/// assert_eq!(iter.next(), Some(Run::new(0, 34)));
 /// assert_eq!(iter.next(), None);
 /// ```
 #[derive(Clone, Debug)]
@@ -1128,22 +1158,22 @@ impl<'a> RLEIter<'a> {
 }
 
 impl<'a> Iterator for RLEIter<'a> {
-    type Item = (usize, usize);
+    type Item = Run;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut run = (0, 0);
+        let mut run = Run::default();
         if self.sigma >= RLE::THRESHOLD {
-            if let Some(value) = self.source.next() { run.0 = value; } else { return None; }
-            if let Some(len) = self.source.next() { run.1 = len + 1; } else { return None; }
+            if let Some(value) = self.source.next() { run.value = value; } else { return None; }
+            if let Some(len) = self.source.next() { run.len = len + 1; } else { return None; }
         } else {
             if let Some(byte) = self.source.byte() {
-                run.0 = (byte as usize) % self.sigma;
-                run.1 = (byte as usize) / self.sigma + 1;
+                run.value = (byte as usize) % self.sigma;
+                run.len = (byte as usize) / self.sigma + 1;
             } else {
                 return None;
             }
-            if run.1 == self.threshold {
-                if let Some(len) = self.source.next() { run.1 += len; } else { return None; }
+            if run.len == self.threshold {
+                if let Some(len) = self.source.next() { run.len += len; } else { return None; }
             }
         }
         return Some(run);


### PR DESCRIPTION
Added several path-based iterators to GBZ:

* `path()`:  over the nodes on the given path.
* `segment_path()`: over the segments on the given path.
* `follow_forward()`: over forward extensions of a search state.
* `follow_backward()`: over backward extensions of a search state.

Additionally, runs and GBWT positions now use `Run` and `Pos` types instead of `(usize, usize)` pairs.