### PR TITLE
Longest common subsequence algorithms

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,11 @@
 
 * New functionality:
   * `GBZ::reference_positions` for finding positions on reference paths for indexing by sequence offsets.
-  * GBZ methods for setting and iterating over reference samples.
+  * GBZ methods for setting reference samples and iterating over them.
+  * Longest common subsequence algorithms:
+    * `lcs()` for two integer sequences.
+    * `path_lcs()` for two paths, weighted by sequence lengths.
+    * `fast_weighted_lcs()` for two integer sequences, weighted by an arbitrary function.
 
 ## GBWT-rs 0.3.0 (2024-01-29)
 

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -4,19 +4,17 @@ use crate::{GBZ, support};
 
 use std::cmp;
 
-/*
 #[cfg(test)]
 mod tests;
-*/
 
 //-----------------------------------------------------------------------------
 
 // FIXME replace with the O(nd) algorithm
-// FIXME tests
 /// Returns the longest common subsequence of integer sequences `a` and `b`, weighted by the given function.
 ///
+/// The subsequence is returned as pairs of positions, and the second return value is the total weight of the LCS.
 /// See [`lcs`] for an unweighted version and [`path_lcs`] for finding the LCS of two paths in a graph.
-pub fn weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) -> (Vec<usize>, usize) {
+pub fn weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) -> (Vec<(usize, usize)>, usize) {
     let mut dp = vec![vec![0; b.len() + 1]; a.len() + 1];
     for i in 0..a.len() {
         for j in 0..b.len() {
@@ -32,7 +30,7 @@ pub fn weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) 
     let mut j = b.len();
     while i > 0 && j > 0 {
         if a[i - 1] == b[j - 1] {
-            result.push(a[i - 1]);
+            result.push((i - 1, j - 1));
             i -= 1;
             j -= 1;
         } else if dp[i][j] == dp[i - 1][j] {
@@ -45,8 +43,9 @@ pub fn weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) 
     (result, dp[a.len()][b.len()])
 }
 
-// FIXME tests
 /// Returns the longest common subsequence of `a` and `b`.
+///
+/// The return value consists of pairs of positions in the input vectors.
 ///
 /// # Examples
 ///
@@ -55,18 +54,19 @@ pub fn weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) 
 ///
 /// let a = vec![1, 2, 3, 4, 5];
 /// let b = vec![2, 4, 6, 8, 10];
-/// assert_eq!(lcs(&a, &b), vec![2, 4]);
+/// let truth = vec![(1, 0), (3, 1)];
+/// assert_eq!(lcs(&a, &b), truth);
 /// ``````
-pub fn lcs(a: &[usize], b: &[usize]) -> Vec<usize> {
+pub fn lcs(a: &[usize], b: &[usize]) -> Vec<(usize, usize)> {
     weighted_lcs(a, b, |_| 1).0
 }
 
-// FIXME tests
 /// Returns the longest common subsequence of paths `a` and `b` in the graph.
 ///
-/// The LCS is weighted by the length of the node, and the second return value is the total weight of the LCS.
-/// The paths are assumed to be valid in the graph.
+/// The LCS is weighted by the length of the node and returned as a vector of pairs of positions.
+/// The second return value is the total weight of the LCS.
 /// If a node is not found in the graph, its length is assumed to be zero.
+/// In such cases, the LCS may not be meaningful.
 ///
 /// # Examples
 ///
@@ -92,17 +92,13 @@ pub fn lcs(a: &[usize], b: &[usize]) -> Vec<usize> {
 /// let b = get_path(&gbz, 2);
 ///
 /// let truth = vec![
-///     support::encode_node(1, Orientation::Forward),
-///     support::encode_node(2, Orientation::Forward),
-///     support::encode_node(5, Orientation::Forward),
-///     support::encode_node(6, Orientation::Forward),
-///     support::encode_node(11, Orientation::Forward),
+///     (0, 0), (1, 1), (3, 3), (4, 4), (6, 6)
 /// ];
 /// let len = 8;
 ///
 /// assert_eq!(algorithms::path_lcs(&a, &b, &gbz), (truth, len));
 /// ```
-pub fn path_lcs(a: &[usize], b: &[usize], graph: &GBZ) -> (Vec<usize>, usize) {
+pub fn path_lcs(a: &[usize], b: &[usize], graph: &GBZ) -> (Vec<(usize, usize)>, usize) {
     let weight = |handle| graph.sequence_len(support::node_id(handle)).unwrap_or(0);
     weighted_lcs(a, b, weight)
 }

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -2,19 +2,23 @@
 
 use crate::{GBZ, support};
 
-use std::cmp;
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
+use std::{cmp, fmt};
 
 #[cfg(test)]
 mod tests;
 
 //-----------------------------------------------------------------------------
 
-// FIXME replace with the O(nd) algorithm
 /// Returns the longest common subsequence of integer sequences `a` and `b`, weighted by the given function.
 ///
 /// The subsequence is returned as pairs of positions, and the second return value is the total weight of the LCS.
-/// See [`lcs`] for an unweighted version and [`path_lcs`] for finding the LCS of two paths in a graph.
-pub fn weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) -> (Vec<(usize, usize)>, usize) {
+/// Weights are applied to the elements of the sequences, and they are assumed to be non-zero.
+/// This version of the algorithm uses naive dynamic programming.
+/// It is not suitable for long sequences.
+/// See [`fast_weighted_lcs`] for an implementation based on Myers' O(nd) algorithm.
+pub fn naive_weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) -> (Vec<(usize, usize)>, usize) {
     let mut dp = vec![vec![0; b.len() + 1]; a.len() + 1];
     for i in 0..a.len() {
         for j in 0..b.len() {
@@ -43,6 +47,241 @@ pub fn weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) 
     (result, dp[a.len()][b.len()])
 }
 
+//-----------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DPPoint {
+    // Twice the total weight of the LCS up to this point.
+    // This guarantees an invariant: `weight + edits = a_prefix_sum + b_prefix_sum`.
+    weight: usize,
+
+    // Non-weighted offset in the first sequence.
+    a_offset: usize,
+
+    // Non-weighted offset in the second sequence.
+    b_offset: usize,
+
+    // Length of the non-weighted run of matches.
+    matches: usize,
+}
+
+impl DPPoint {
+    fn new(weight: usize, a_offset: usize, b_offset: usize) -> DPPoint {
+        DPPoint {
+            weight, a_offset, b_offset, matches: 0,
+        }
+    }
+}
+
+impl Display for DPPoint {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "(weight {}, a {}, b {}, matches {})", self.weight, self.a_offset, self.b_offset, self.matches)
+    }
+}
+
+struct DPMatrix<'a> {
+    // First sequence.
+    a: &'a [usize],
+
+    // Second sequence.
+    b: &'a [usize],
+
+    // Prefix sum of weights on the first sequence.
+    a_weights: Vec<usize>,
+
+    // Prefix sum of weights on the second sequence.
+    b_weights: Vec<usize>,
+
+    // Furthest point for the given number of weighted edits on the weighted diagonal.
+    // A diagonal is a_prefix_sum - b_prefix_sum.
+    // The point refers to the first unprocessed pair of offsets.
+    points: BTreeMap<(usize, isize), DPPoint>,
+}
+
+impl<'a> DPMatrix<'a> {
+    fn prefix_sum<F: Fn(usize) -> usize>(sequence: &[usize], weight: F) -> Vec<usize> {
+        let mut result = Vec::with_capacity(sequence.len() + 1);
+        result.push(0);
+        for i in 0..sequence.len() {
+            result.push(result[i] + weight(sequence[i]));
+        }
+        result
+    }
+
+    fn new<F: Fn(usize) -> usize>(a: &'a [usize], b: &'a [usize], weight: F) -> Self {
+        let a_weights = Self::prefix_sum(a, &weight);
+        let b_weights = Self::prefix_sum(b, &weight);
+        let mut points = BTreeMap::new();
+        points.insert((0, 0), DPPoint::new(0, 0, 0));
+        DPMatrix {
+            a, b, a_weights, b_weights, points
+        }
+    }
+
+    fn diagonals_for(&self, edits: usize) -> Vec<isize> {
+        let mut result = Vec::new();
+        for ((_, diagonal), _) in self.points.range((edits, isize::MIN)..(edits + 1, isize::MIN)) {
+            result.push(*diagonal);
+        }
+        result
+    }
+
+    // Inserts the point if it is better than the existing one.
+    fn try_insert(&mut self, edits: usize, diagonal: isize, point: DPPoint) {
+        if let Some(existing) = self.points.get_mut(&(edits, diagonal)) {
+            if point.weight > existing.weight {
+                *existing = point;
+            }
+        } else {
+            self.points.insert((edits, diagonal), point);
+        }
+    }
+
+    fn a_weight(&self, offset: usize) -> usize {
+        self.a_weights[offset + 1] - self.a_weights[offset]
+    }
+
+    fn b_weight(&self, offset: usize) -> usize {
+        self.b_weights[offset + 1] - self.b_weights[offset]
+    }
+
+    // Extends matches over all diagonals for the given number of weighted edits.
+    // Also adds successor points reachable with a single edit from each extension.
+    // Returns the point if we reached the end.
+    fn extend(&mut self, edits: usize) -> Option<DPPoint> {
+        let diagonals = self.diagonals_for(edits);
+        for diagonal in diagonals.into_iter() {
+            let point = self.points.get(&(edits, diagonal)).copied();
+            if point.is_none() {
+                continue;
+            }
+            let mut point = point.unwrap();
+            while point.a_offset < self.a.len() && point.b_offset < self.b.len() && self.a[point.a_offset] == self.b[point.b_offset] {
+                point.weight += 2 * self.a_weight(point.a_offset);
+                point.a_offset += 1;
+                point.b_offset += 1;
+                point.matches += 1;
+            }
+            if point.matches > 0 {
+                self.points.insert((edits, diagonal), point);
+            }
+            if point.a_offset == self.a.len() && point.b_offset == self.b.len() {
+                return Some(point.clone());
+            }
+            if point.a_offset < self.a.len() {
+                let weight = self.a_weight(point.a_offset);
+                let new_point = DPPoint::new(point.weight, point.a_offset + 1, point.b_offset);
+                self.try_insert(edits + weight, diagonal + (weight as isize), new_point);
+            }
+            if point.b_offset < self.b.len() {
+                let weight = self.b_weight(point.b_offset);
+                let new_point = DPPoint::new(point.weight, point.a_offset, point.b_offset + 1);
+                self.try_insert(edits + weight, diagonal - (weight as isize), new_point);
+            }
+        }
+        None
+    }
+
+    // Returns the next possible number of edits after the given number.
+    // This assumes that `extend` has been called for the given number of edits.
+    fn next_edits(&self, edits: usize) -> Option<usize> {
+        if let Some(((value, _), _)) = self.points.range((edits + 1, isize::MIN)..).next() {
+            Some(*value)
+        } else {
+            None
+        }
+    }
+
+    // Returns the predecessor point and number of edits for the given point and number of edits.
+    fn predecessor(&self, a_offset: usize, b_offset: usize, edits: usize) -> Option<(DPPoint, usize)> {
+        let diagonal = (self.a_weights[a_offset] as isize) - (self.b_weights[b_offset] as isize);
+        let prev = if a_offset > 0 && self.a_weight(a_offset - 1) <= edits {
+            let weight = self.a_weight(a_offset - 1);
+            self.points.get(&(edits - weight, diagonal - (weight as isize))).copied()
+        } else {
+            None
+        };
+        let next = if b_offset > 0 && self.b_weight(b_offset - 1) <= edits {
+            let weight = self.b_weight(b_offset - 1);
+            self.points.get(&(edits - weight, diagonal + (weight as isize))).copied()
+        } else {
+            None
+        };
+        if prev.is_some() && next.is_some() {
+            let prev = prev.unwrap();
+            let next = next.unwrap();
+            if prev.weight > next.weight {
+                Some((prev, edits - self.a_weight(a_offset - 1)))
+            } else {
+                Some((next, edits - self.b_weight(b_offset - 1)))
+            }
+        } else if let Some(point) = prev {
+            Some((point, edits - self.a_weight(a_offset - 1)))
+        } else if let Some(point) = next {
+            Some((point, edits - self.b_weight(b_offset - 1)))
+        } else {
+            None
+        }
+    }
+}
+
+// FIXME tests against the naive algorithm
+/// Returns the longest common subsequence of integer sequences `a` and `b`, weighted by the given function.
+///
+/// The subsequence is returned as pairs of positions, and the second return value is the total weight of the LCS.
+/// Weights are applied to the elements of the sequences, and they are assumed to be non-zero.
+/// This version of the algorithm is based on Myers' O(nd) algorithm.
+/// It is efficient with long sequences, as long as they are similar.
+/// See [`naive_weighted_lcs`] for an implementation using naive dynamic programming.
+///
+/// The following specializations are available:
+///
+/// * [`lcs`] for unweighted LCS.
+/// * [`path_lcs`] for paths in a graph, using sequence lengths as weights.
+pub fn fast_weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) -> (Vec<(usize, usize)>, usize) {
+    if a.is_empty() || b.is_empty() {
+        return (Vec::new(), 0);
+    }
+
+    // Find the furthest point on each diagonal with each possible number of edits, until we reach the end.
+    let mut matrix = DPMatrix::new(a, b, &weight);
+    let mut edits = 0;
+    let mut point = DPPoint::new(0, 0, 0);
+    loop {
+        if let Some(next_point) = matrix.extend(edits) {
+            point = next_point;
+            break;
+        }
+        if let Some(next_edits) = matrix.next_edits(edits) {
+            edits = next_edits;
+        } else {
+            // This should not happen.
+            break;
+        }
+    }
+
+    // Trace back the LCS.
+    let mut result = Vec::new();
+    let final_weight = point.weight / 2;
+    loop {
+        for _ in 0..point.matches {
+            point.a_offset -= 1;
+            point.b_offset -= 1;
+            result.push((point.a_offset, point.b_offset));
+        }
+        if let Some((p, e)) = matrix.predecessor(point.a_offset, point.b_offset, edits) {
+            point = p;
+            edits = e;
+        } else {
+            break;
+        }
+    }
+    result.reverse();
+    (result, final_weight)
+}
+
+//-----------------------------------------------------------------------------
+
 /// Returns the longest common subsequence of `a` and `b`.
 ///
 /// The return value consists of pairs of positions in the input vectors.
@@ -58,7 +297,7 @@ pub fn weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) 
 /// assert_eq!(lcs(&a, &b), truth);
 /// ``````
 pub fn lcs(a: &[usize], b: &[usize]) -> Vec<(usize, usize)> {
-    weighted_lcs(a, b, |_| 1).0
+    fast_weighted_lcs(a, b, |_| 1).0
 }
 
 /// Returns the longest common subsequence of paths `a` and `b` in the graph.
@@ -100,7 +339,7 @@ pub fn lcs(a: &[usize], b: &[usize]) -> Vec<(usize, usize)> {
 /// ```
 pub fn path_lcs(a: &[usize], b: &[usize], graph: &GBZ) -> (Vec<(usize, usize)>, usize) {
     let weight = |handle| graph.sequence_len(support::node_id(handle)).unwrap_or(0);
-    weighted_lcs(a, b, weight)
+    fast_weighted_lcs(a, b, weight)
 }
 
 //-----------------------------------------------------------------------------

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -49,6 +49,9 @@ pub fn naive_weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weigh
 
 //-----------------------------------------------------------------------------
 
+// TODO: We do not need to store the weight. Due to the invariant, we can derive it from
+// edits and the prefix sums.
+// TODO: We could make this more space-efficient by using 32-bit integers.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct DPPoint {
     // Twice the total weight of the LCS up to this point.
@@ -225,7 +228,6 @@ impl<'a> DPMatrix<'a> {
     }
 }
 
-// FIXME tests against the naive algorithm
 /// Returns the longest common subsequence of integer sequences `a` and `b`, weighted by the given function.
 ///
 /// The subsequence is returned as pairs of positions, and the second return value is the total weight of the LCS.

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -20,10 +20,10 @@ mod tests;
 /// See [`fast_weighted_lcs`] for an implementation based on Myers' O(nd) algorithm.
 pub fn naive_weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) -> (Vec<(usize, usize)>, usize) {
     let mut dp = vec![vec![0; b.len() + 1]; a.len() + 1];
-    for i in 0..a.len() {
-        for j in 0..b.len() {
+    for (i, a_val) in a.iter().enumerate() {
+        for (j, b_val) in b.iter().enumerate() {
             dp[i + 1][j + 1] = cmp::max(dp[i + 1][j], dp[i][j + 1]);
-            if a[i] == b[j] {
+            if a_val == b_val {
                 dp[i + 1][j + 1] = cmp::max(dp[i + 1][j + 1], dp[i][j] + weight(a[i]));
             }
         }
@@ -169,7 +169,7 @@ impl<'a> DPMatrix<'a> {
                 self.points.insert((edits, diagonal), point);
             }
             if point.a_offset == self.a.len() && point.b_offset == self.b.len() {
-                return Some(point.clone());
+                return Some(point);
             }
             if point.a_offset < self.a.len() {
                 let weight = self.a_weight(point.a_offset);

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -1,0 +1,110 @@
+//! Algorithms using GBWT and GBZ.
+
+use crate::{GBZ, support};
+
+use std::cmp;
+
+/*
+#[cfg(test)]
+mod tests;
+*/
+
+//-----------------------------------------------------------------------------
+
+// FIXME replace with the O(nd) algorithm
+// FIXME tests
+/// Returns the longest common subsequence of integer sequences `a` and `b`, weighted by the given function.
+///
+/// See [`lcs`] for an unweighted version and [`path_lcs`] for finding the LCS of two paths in a graph.
+pub fn weighted_lcs<F: Fn(usize) -> usize>(a: &[usize], b: &[usize], weight: F) -> (Vec<usize>, usize) {
+    let mut dp = vec![vec![0; b.len() + 1]; a.len() + 1];
+    for i in 0..a.len() {
+        for j in 0..b.len() {
+            dp[i + 1][j + 1] = cmp::max(dp[i + 1][j], dp[i][j + 1]);
+            if a[i] == b[j] {
+                dp[i + 1][j + 1] = cmp::max(dp[i + 1][j + 1], dp[i][j] + weight(a[i]));
+            }
+        }
+    }
+
+    let mut result = Vec::new();
+    let mut i = a.len();
+    let mut j = b.len();
+    while i > 0 && j > 0 {
+        if a[i - 1] == b[j - 1] {
+            result.push(a[i - 1]);
+            i -= 1;
+            j -= 1;
+        } else if dp[i][j] == dp[i - 1][j] {
+            i -= 1;
+        } else {
+            j -= 1;
+        }
+    }
+    result.reverse();
+    (result, dp[a.len()][b.len()])
+}
+
+// FIXME tests
+/// Returns the longest common subsequence of `a` and `b`.
+///
+/// # Examples
+///
+/// ```
+/// use gbwt::algorithms::lcs;
+///
+/// let a = vec![1, 2, 3, 4, 5];
+/// let b = vec![2, 4, 6, 8, 10];
+/// assert_eq!(lcs(&a, &b), vec![2, 4]);
+/// ``````
+pub fn lcs(a: &[usize], b: &[usize]) -> Vec<usize> {
+    weighted_lcs(a, b, |_| 1).0
+}
+
+// FIXME tests
+/// Returns the longest common subsequence of paths `a` and `b` in the graph.
+///
+/// The LCS is weighted by the length of the node, and the second return value is the total weight of the LCS.
+/// The paths are assumed to be valid in the graph.
+/// If a node is not found in the graph, its length is assumed to be zero.
+///
+/// # Examples
+///
+/// ```
+/// use gbwt::{GBZ, Orientation, algorithms};
+/// use gbwt::support;
+/// use simple_sds::serialize;
+///
+/// let filename = support::get_test_data("translation.gbz");
+/// let gbz: GBZ = serialize::load_from(&filename).unwrap();
+///
+/// fn get_path(graph: &GBZ, path_id: usize) -> Vec<usize> {
+///     graph.path(path_id, Orientation::Forward)
+///         .unwrap()
+///         .map(|(id, o)| support::encode_node(id, o))
+///         .collect()
+/// }
+///
+/// // (1: GA), (2: T), (3: T), (5: CA), (6: G), (9: A), (11: TA)
+/// let a = get_path(&gbz, 1);
+///
+/// // (1: GA), (2: T), (4: A), (5: CA), (6: G), (10: T), (11: TA)
+/// let b = get_path(&gbz, 2);
+///
+/// let truth = vec![
+///     support::encode_node(1, Orientation::Forward),
+///     support::encode_node(2, Orientation::Forward),
+///     support::encode_node(5, Orientation::Forward),
+///     support::encode_node(6, Orientation::Forward),
+///     support::encode_node(11, Orientation::Forward),
+/// ];
+/// let len = 8;
+///
+/// assert_eq!(algorithms::path_lcs(&a, &b, &gbz), (truth, len));
+/// ```
+pub fn path_lcs(a: &[usize], b: &[usize], graph: &GBZ) -> (Vec<usize>, usize) {
+    let weight = |handle| graph.sequence_len(support::node_id(handle)).unwrap_or(0);
+    weighted_lcs(a, b, weight)
+}
+
+//-----------------------------------------------------------------------------

--- a/src/algorithms/tests.rs
+++ b/src/algorithms/tests.rs
@@ -95,7 +95,7 @@ fn random_lcs_instance(len: usize, sigma: usize) {
 fn random_lcs() {
     random_lcs_instance(10, 5);
     random_lcs_instance(100, 10);
-    random_lcs_instance(1000, 20);
+    random_lcs_instance(300, 20);
 }
 
 // TODO: Large almost equal sequences

--- a/src/algorithms/tests.rs
+++ b/src/algorithms/tests.rs
@@ -1,0 +1,218 @@
+use super::*;
+
+use crate::Orientation;
+use rand::Rng;
+use simple_sds::serialize;
+
+//use simple_sds::serialize;
+
+//-----------------------------------------------------------------------------
+
+#[test]
+fn empty_lcs() {
+    let a: Vec<usize> = Vec::new();
+    let b: Vec<usize> = Vec::new();
+    assert!(lcs(&a, &b).is_empty(), "Non-empty LCS for empty inputs");
+
+    let non_empty: Vec<usize> = vec![1, 2, 3];
+    assert!(lcs(&a, &non_empty).is_empty(), "Non-empty LCS for empty first input");
+    assert!(lcs(&non_empty, &b).is_empty(), "Non-empty LCS for empty second input");
+}
+
+#[test]
+fn first_last_lcs() {
+    let a: Vec<usize> = vec![1, 2, 3, 4, 5];
+
+    let no_no: Vec<usize> = vec![6, 2, 4, 7];
+    let no_no_left: Vec<(usize, usize)> = vec![(1, 1), (2, 3)];
+    assert_eq!(lcs(&no_no, &a), no_no_left, "Incorrect LCS for no first / no last / left");
+    let no_no_right: Vec<(usize, usize)> = vec![(1, 1), (3, 2)];
+    assert_eq!(lcs(&a, &no_no), no_no_right, "Incorrect LCS for no first / no last / right");
+
+    let no_yes: Vec<usize> = vec![6, 2, 4, 5];
+    let no_yes_left: Vec<(usize, usize)> = vec![(1, 1), (2, 3), (3, 4)];
+    assert_eq!(lcs(&no_yes, &a), no_yes_left, "Incorrect LCS for no first / yes last / left");
+    let no_yes_right: Vec<(usize, usize)> = vec![(1, 1), (3, 2), (4, 3)];
+    assert_eq!(lcs(&a, &no_yes), no_yes_right, "Incorrect LCS for no first / yes last / right");
+
+    let yes_no: Vec<usize> = vec![1, 2, 4, 7];
+    let yes_no_left: Vec<(usize, usize)> = vec![(0, 0), (1, 1), (2, 3)];
+    assert_eq!(lcs(&yes_no, &a), yes_no_left, "Incorrect LCS for yes first / no last / left");
+    let yes_no_right: Vec<(usize, usize)> = vec![(0, 0), (1, 1), (3, 2)];
+    assert_eq!(lcs(&a, &yes_no), yes_no_right, "Incorrect LCS for yes first / no last / right");
+
+    let yes_yes: Vec<usize> = vec![1, 2, 4, 5];
+    let yes_yes_left: Vec<(usize, usize)> = vec![(0, 0), (1, 1), (2, 3), (3, 4)];
+    assert_eq!(lcs(&yes_yes, &a), yes_yes_left, "Incorrect LCS for yes first / yes last / left");
+    let yes_yes_right: Vec<(usize, usize)> = vec![(0, 0), (1, 1), (3, 2), (4, 3)];
+    assert_eq!(lcs(&a, &yes_yes), yes_yes_right, "Incorrect LCS for yes first / yes last / right");
+}
+
+#[test]
+fn minimal_maximal_lcs() {
+    let four_odd: Vec<usize> = vec![1, 3, 5, 7];
+    let five_odd: Vec<usize> = vec![1, 3, 5, 7, 9];
+    let four_even: Vec<usize> = vec![4, 6, 8, 10];
+    let five_even: Vec<usize> = vec![2, 4, 6, 8, 10];
+
+    assert!(lcs(&four_odd, &four_even).is_empty(), "Non-empty LCS for disjoint inputs");
+
+    let four_four: Vec<(usize, usize)> = vec![(0, 0), (1, 1), (2, 2), (3, 3)];
+    assert_eq!(lcs(&four_odd, &four_odd), four_four, "Incorrect LCS for equal inputs");
+
+    let prefix: Vec<(usize, usize)> = vec![(0, 0), (1, 1), (2, 2), (3, 3)];
+    assert_eq!(lcs(&four_odd, &five_odd), prefix, "Incorrect LCS for prefix / full");
+    assert_eq!(lcs(&five_odd, &four_odd), prefix, "Incorrect LCS for full / prefix");
+
+    let left_suffix: Vec<(usize, usize)> = vec![(0, 1), (1, 2), (2, 3), (3, 4)];
+    assert_eq!(lcs(&four_even, &five_even), left_suffix, "Incorrect LCS for suffix / full");
+    let right_suffix: Vec<(usize, usize)> = vec![(1, 0), (2, 1), (3, 2), (4, 3)];
+    assert_eq!(lcs(&five_even, &four_even), right_suffix, "Incorrect LCS for full / suffix");
+}
+
+fn random_sequence(len: usize, sigma: usize) -> Vec<usize> {
+    let mut rng = rand::thread_rng();
+    (0..len).map(|_| rng.gen_range(0..sigma)).collect()
+}
+
+fn random_lcs_instance(len: usize, sigma: usize) {
+    let left = random_sequence(len, sigma);
+    let right = random_sequence(len, sigma);
+    let result = lcs(&left, &right);
+
+    for i in 0..result.len() {
+        assert!(result[i].0 < left.len(), "Invalid left LCS position {} (len {}, sigma {})", i, len, sigma);
+        assert!(result[i].1 < right.len(), "Invalid right LCS position {} (len {}, sigma {})", i, len, sigma);
+        if i > 0 {
+            assert!(result[i].0 > result[i - 1].0, "Non-increasing left LCS position {} (len {}, sigma {})", i, len, sigma);
+            assert!(result[i].1 > result[i - 1].1, "Non-increasing right LCS position {} (len {}, sigma {})", i, len, sigma);
+        }
+        assert_eq!(left[result[i].0], right[result[i].1], "Incorrect LCS element {} (len {}, sigma {})", i, len, sigma);
+    }
+}
+
+#[test]
+fn random_lcs() {
+    random_lcs_instance(10, 5);
+    random_lcs_instance(100, 10);
+    random_lcs_instance(1000, 20);
+}
+
+// TODO: Large almost equal sequences
+
+//-----------------------------------------------------------------------------
+
+fn extract_path(graph: &GBZ, path_id: usize, orientation: Orientation) -> Vec<usize> {
+    graph.path(path_id, orientation)
+        .unwrap()
+        .map(|(id, o)| support::encode_node(id, o))
+        .collect()
+}
+
+fn node_len(graph: &GBZ, handle: usize) -> usize {
+    graph.sequence_len(support::node_id(handle)).unwrap_or(0)
+}
+
+fn path_len(graph: &GBZ, path: &[usize]) -> usize {
+    path.iter().map(|handle| node_len(graph, *handle)).sum()
+}
+
+#[test]
+fn empty_path_lcs() {
+    let filename = support::get_test_data("translation.gbz");
+    let graph: GBZ = serialize::load_from(&filename).unwrap();
+    let empty: Vec<usize> = Vec::new();
+    let path = extract_path(&graph, 0, Orientation::Forward);
+
+    let truth = (Vec::new(), 0);
+    assert_eq!(path_lcs(&empty, &empty, &graph), truth, "Non-empty LCS for empty inputs");
+    assert_eq!(path_lcs(&empty, &path, &graph), truth, "Non-empty LCS for empty first input");
+    assert_eq!(path_lcs(&path, &empty, &graph), truth, "Non-empty LCS for empty second input");
+
+    let reverse = extract_path(&graph, 0, Orientation::Reverse);
+    assert_eq!(path_lcs(&path, &reverse, &graph), truth, "Non-empty LCS non-overlapping paths");
+}
+
+#[test]
+fn identical_path_lcs() {
+    let filename = support::get_test_data("translation.gbz");
+    let graph: GBZ = serialize::load_from(&filename).unwrap();
+
+    for path_id in 0..graph.paths() {
+        for orientation in [Orientation::Forward, Orientation::Reverse] {
+            let path = extract_path(&graph, path_id, orientation);
+            let truth = path.iter().enumerate().map(|(i, _)| (i, i)).collect();
+            let len = path_len(&graph, &path);
+            assert_eq!(path_lcs(&path, &path, &graph), (truth, len), "Incorrect LCS for identical paths {} {}", path_id, orientation);
+        }
+    }
+}
+
+fn path_lcs_instance(graph: &GBZ, left_id: usize, right_id: usize, orientation: Orientation) {
+    let left = extract_path(graph, left_id, orientation);
+    let right = extract_path(graph, right_id, orientation);
+    let (result, len) = path_lcs(&left, &right, graph);
+
+    let mut total_len = 0;
+    let test = format!("(paths {} and {} {})", left_id, right_id, orientation);
+    for i in 0..result.len() {
+        assert!(result[i].0 < left.len(), "Invalid left LCS position {} {}", i, test);
+        assert!(result[i].1 < right.len(), "Invalid right LCS position {} {}", i, test);
+        if i > 0 {
+            assert!(result[i].0 > result[i - 1].0, "Non-increasing left LCS position {} {}", i, test);
+            assert!(result[i].1 > result[i - 1].1, "Non-increasing right LCS position {} {}", i, test);
+        }
+        assert_eq!(left[result[i].0], right[result[i].1], "Incorrect LCS element {} {}", i, test);
+        total_len += node_len(graph, left[result[i].0]);
+    }
+    assert_eq!(total_len, len, "Incorrect LCS length {}", test);
+}
+
+#[test]
+fn real_path_lcs() {
+    let filename = support::get_test_data("translation.gbz");
+    let graph: GBZ = serialize::load_from(&filename).unwrap();
+
+    for left_id in 0..graph.paths() {
+        for right_id in 0..graph.paths() {
+            for orientation in [Orientation::Forward, Orientation::Reverse] {
+                path_lcs_instance(&graph, left_id, right_id, orientation);
+            }
+        }
+    }
+}
+
+#[test]
+fn path_lcs_weights() {
+    let filename = support::get_test_data("translation.gbz");
+    let graph: GBZ = serialize::load_from(&filename).unwrap();
+
+    // This is an artificial scenario where the weights matter.
+    // 1, 5, and 11 are weight 2 nodes and form the path LCS.
+    // Normal LCS would return 1, 2, 3, 4.
+    let left: Vec<usize> = vec![
+        support::encode_node(1, Orientation::Forward),
+        support::encode_node(2, Orientation::Forward),
+        support::encode_node(3, Orientation::Forward),
+        support::encode_node(4, Orientation::Forward),
+        support::encode_node(5, Orientation::Forward),
+        support::encode_node(11, Orientation::Forward),
+    ];
+    let right: Vec<usize> = vec![
+        support::encode_node(1, Orientation::Forward),
+        support::encode_node(5, Orientation::Forward),
+        support::encode_node(11, Orientation::Forward),
+        support::encode_node(2, Orientation::Forward),
+        support::encode_node(3, Orientation::Forward),
+        support::encode_node(4, Orientation::Forward),
+    ];
+
+    let unweighted_truth: Vec<(usize, usize)> = vec![(0, 0), (1, 3), (2, 4), (3, 5)];
+    let path_truth: Vec<(usize, usize)> = vec![(0, 0), (4, 1), (5, 2)];
+    let path_len = 6;
+
+    assert_eq!(lcs(&left, &right), unweighted_truth, "Incorrect unweighted LCS");
+    assert_eq!(path_lcs(&left, &right, &graph), (path_truth, path_len), "Incorrect path LCS");
+}
+
+//-----------------------------------------------------------------------------

--- a/src/gbwt.rs
+++ b/src/gbwt.rs
@@ -529,7 +529,7 @@ impl BidirectionalState {
 
 /// An iterator over a sequence in [`GBWT`].
 ///
-/// The type of `Item` is [`usize`].
+/// The type of `Item` is [`prim@usize`].
 ///
 /// # Examples
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 
 #![allow(clippy::uninlined_format_args)]
 
+pub mod algorithms;
 pub mod bwt;
 pub mod gbwt;
 pub mod gbz;


### PR DESCRIPTION
Added a number of algorithms for finding the longest common subsequence of two integer sequence. The algorithms are in module `algorithms`. They include:

* `naive_weighted_lcs()`: Naive dynamic programming with an arbitrary weight function for the integers.
* `fast_weighted_lcs()`: Myers' O(nd) algorithm with an arbitrary weight function for the integers.
* `lcs()`: Unweighted LCS using the fast algorithm.
* `path_lcs()`: Fast algorithm for paths in a graph, with sequence length used as the weight of a node.

As a pangenome graph represents an alignment of haplotype sequences, the last algorithm can be used for finding that alignment.