### PR TITLE
Try to fix find_chains

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -1,7 +1,7 @@
 //! Algorithms using GBWT and GBZ.
 
-use crate::{GBZ, Orientation, support};
-use crate::support::Chains;
+use crate::{GBZ, Orientation};
+use crate::support::{self, Chains};
 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt::{Display, Formatter};
@@ -356,8 +356,7 @@ pub fn path_lcs(a: &[usize], b: &[usize], graph: &GBZ) -> (Vec<(usize, usize)>, 
 /// A top-level chain is a sequence of boundary nodes bordering snarls in a weakly connected component.
 /// The result contains links between consecutive boundary nodes in each chain.
 ///
-/// Each component must have exactly two tip nodes.
-/// All articulation points in underlying undirected graph of the component must be between the tips.
+/// Each component must have exactly two tip nodes, and there must be a directed path between them.
 /// If these assumptions do not hold, the component is skipped and not included in the result.
 /// In more complex cases, the chains can be extracted from a snarl decomposition or a distance index using `vg chains`.
 ///
@@ -400,23 +399,20 @@ pub fn find_chains(graph: &GBZ) -> Chains {
         if tips.len() != 2 {
             continue;
         }
+        let from_handle = tips[0];
+        let to_handle = support::flip_node(tips[1]);
+        let bridges = find_bridge_nodes(graph, component);
 
-        // Find articulation points (bridges) in the underlying undirected graph of the component.
-        // Then add the tips to get the set of chain nodes.
-        let mut chain_node_ids = find_articulation_points(graph, component);
-        for tip in tips.iter() {
-            chain_node_ids.insert(support::node_id(*tip as usize) as u32);
-        }
-
-        // This will return empty vectors if some chain nodes were not visited.
-        let (chain_handles, is_snarl) = walk_chain(graph, tips[0], &chain_node_ids);
-        if chain_handles.is_empty() {
+        // Determine all handles in the top-level chain and which of them are snarl entry points.
+        let result = walk_chain(graph, from_handle, to_handle, &bridges);
+        if result.is_none() {
             continue;
         }
+        let (chain_handles, is_snarl_entry) = result.unwrap();
+        drop(bridges);
 
-        // Extract boundary nodes: chain nodes where at least one adjacent edge is a snarl.
-        // is_snarl[i] indicates whether the link between chain_handles[i] and chain_handles[i + 1] is a snarl.
-        let mut is_boundary = is_snarl;
+        // We only want to extract the subsequence that consists of boundary nodes of snarls.
+        let mut is_boundary = is_snarl_entry;
         for i in (0..(is_boundary.len() - 1)).rev() {
             if is_boundary[i] {
                 is_boundary[i + 1] = true;
@@ -440,7 +436,7 @@ pub fn find_chains(graph: &GBZ) -> Chains {
 
 // Returns inward-oriented handles for tip nodes in the component.
 // A tip node has successors on one side but not the other.
-fn find_tips(graph: &GBZ, component: &[usize]) -> Vec<u32> {
+fn find_tips(graph: &GBZ, component: &[usize]) -> Vec<usize> {
     let mut tips = Vec::new();
     for &node_id in component {
         let fwd_succ = graph.successors(node_id, Orientation::Forward)
@@ -456,88 +452,108 @@ fn find_tips(graph: &GBZ, component: &[usize]) -> Vec<u32> {
         }
         // Tip: has edges on one side only. Inward handle is the orientation with successors.
         if fwd_succ > 0 {
-            tips.push(support::encode_node(node_id, Orientation::Forward) as u32);
+            tips.push(support::encode_node(node_id, Orientation::Forward));
         } else {
-            tips.push(support::encode_node(node_id, Orientation::Reverse) as u32);
+            tips.push(support::encode_node(node_id, Orientation::Reverse));
         }
     }
     tips
 }
 
-// Finds articulation points in the underlying undirected graph of a component using Tarjan's algorithm.
+// Finds bridge nodes using a variant of Tarjan's algorithm.
 // Returns node ids (not handles).
-fn find_articulation_points(graph: &GBZ, component: &[usize]) -> HashSet<u32> {
+fn find_bridge_nodes(graph: &GBZ, component: &[usize]) -> HashSet<u32> {
     // Map from node ids to indices in the component vector.
-    let mut index_map: HashMap<u32, u32> = HashMap::new();
+    let mut node_to_index: HashMap<u32, u32> = HashMap::new();
     for (i, &node_id) in component.iter().enumerate() {
-        index_map.insert(node_id as u32, i as u32);
+        node_to_index.insert(node_id as u32, i as u32);
     }
+    let node_to_index = node_to_index;
 
-    let n = component.len();
-    let mut discovered = vec![0u32; n]; // Discovery time (rank) of each node in DFS.
-    let mut low = vec![0u32; n]; // Lowest discovery time reachable from the node via DFS tree edges and back edges.
+    // These arrays are indexed by encoded node sides, except that we use indexes in
+    // the component vector in place of node ids. Each node side is effectively
+    // considered a separate node.
+    let n: usize = 2 * component.len();
     let mut visited = vec![false; n];
+    let mut preorder_rank = vec![0u32; n];
+    let mut lowest_reachable = vec![0u32; n];
     let mut parent = vec![u32::MAX; n];
     let mut result = HashSet::new();
     let mut timer = 0u32;
 
-    // Get the `i`-th neighbor of the node with id `node_id` in the component, if it exists.
-    // We assume that node degrees are low and it is more efficient to iterate over neighbors than to store them in a vector.
-    let get_neighbor = |node_id: u32, i: u32| -> Option<u32> {
-        let mut nbrs = HashSet::new();
-        for orientation in [Orientation::Forward, Orientation::Reverse] {
-            if let Some(iter) = graph.successors(node_id as usize, orientation) {
-                for (next_id, _) in iter {
-                    if index_map.contains_key(&(next_id as u32)) {
-                        nbrs.insert(next_id as u32);
-                        if nbrs.len() > i as usize {
-                            return Some(next_id as u32);
-                        }
-                    }
+    // Returns the `i`-th neighbor of an encoded node side. The first neighbor (`i == 0`)
+    // is the other side of the node, and the rest are the actual neighbors of the side.
+    // Because we have to decompress the edges for each call, we may just as well iterate
+    // over them.
+    let get_neighbor = |encoded_side: u32, i: u32| -> Option<u32> {
+        if i == 0 {
+            // The first neighbor is the other side of the node.
+            return Some(support::flip_node_side(encoded_side as usize) as u32);
+        }
+
+        let (node_index, side) = support::decode_node_side(encoded_side as usize);
+        let node_id = component[node_index];
+        let orientation = support::exit_orientation(side);
+        if let Some(iter) = graph.successors(node_id, orientation) {
+            for (j, (next_id, next_o)) in iter.enumerate() {
+                if j + 1 == i as usize {
+                    let next_index = node_to_index[&(next_id as u32)];
+                    let next_side = support::entry_side(next_o);
+                    let next = support::encode_node_side(next_index as usize, next_side) as u32;
+                    return Some(next);
                 }
             }
         }
         None
     };
 
-    // Iterative Tarjan's algorithm for articulation points.
-    // Stack entries: (node index, next neighbor).
+    // Iterative Tarjan's algorithm for bridges. We only report the "internal edges" connecting the sides
+    // of the same node. If there is also an external edge connecting the sides, the node is not a bridge.
+    // Stack entries: (encoded side, next neighbor).
     let mut stack: Vec<(u32, u32)> = Vec::new();
     visited[0] = true;
-    discovered[0] = timer;
-    low[0] = timer;
+    preorder_rank[0] = timer;
+    lowest_reachable[0] = timer;
     timer += 1;
     stack.push((0, 0));
 
-    while let Some((from_index, next_neighbor)) = stack.last_mut() {
-        if let Some(to_id) = get_neighbor(component[*from_index as usize] as u32, *next_neighbor) {
+    while let Some((encoded_from, next_neighbor)) = stack.last_mut() {
+        if let Some(encoded_to) = get_neighbor(*encoded_from, *next_neighbor) {
             *next_neighbor += 1;
-            let to_index = index_map[&to_id];
-            if !visited[to_index as usize] {
-                visited[to_index as usize] = true;
-                discovered[to_index as usize] = timer;
-                low[to_index as usize] = timer;
+            if !visited[encoded_to as usize] {
+                visited[encoded_to as usize] = true;
+                preorder_rank[encoded_to as usize] = timer;
+                lowest_reachable[encoded_to as usize] = timer;
                 timer += 1;
-                parent[to_index as usize] = *from_index;
-                stack.push((to_index, 0));
-            } else if to_index != parent[*from_index as usize] {
-                low[*from_index as usize] = cmp::min(low[*from_index as usize], discovered[to_index as usize]);
+                parent[encoded_to as usize] = *encoded_from;
+                stack.push((encoded_to, 0));
+            } else {
+                // We update `lowest_reachable` if this is a back edge. If the edge is
+                // to the parent, it can still be a back edge if it's to the other side
+                // of the same node using an external edge (in the actual edge list).
+                let is_parent = encoded_to == parent[*encoded_from as usize];
+                let is_other_side = encoded_to == support::flip_node_side(*encoded_from as usize) as u32;
+                let is_external_edge = *next_neighbor > 1;
+                if !is_parent || (is_other_side && is_external_edge) {
+                    lowest_reachable[*encoded_from as usize] = cmp::min(
+                        lowest_reachable[*encoded_from as usize], preorder_rank[encoded_to as usize]
+                    );
+                }
             }
         } else {
             // Done processing node from, pop and update parent.
-            let from_index = *from_index;
+            let encoded_from = *encoded_from;
             stack.pop();
-            if let Some((parent_index, _)) = stack.last() {
-                low[*parent_index as usize] = cmp::min(low[*parent_index as usize], low[from_index as usize]);
-                // Check if parent_index is an articulation point via child from_index.
-                if parent[*parent_index as usize] == u32::MAX {
-                    // parent_index is the root; it's an articulation point (or a tip) if it has 2+ children in DFS tree.
-                    let child_count = parent.iter().filter(|&&p| p == *parent_index).count();
-                    if child_count > 1 {
-                        result.insert(component[*parent_index as usize] as u32);
-                    }
-                } else if low[from_index as usize] >= discovered[*parent_index as usize] {
-                    result.insert(component[*parent_index as usize] as u32);
+            if let Some((encoded_parent, _)) = stack.last() {
+                lowest_reachable[*encoded_parent as usize] = cmp::min(
+                    lowest_reachable[*encoded_parent as usize], lowest_reachable[encoded_from as usize]
+                );
+                if lowest_reachable[encoded_from as usize] > preorder_rank[*encoded_parent as usize]
+                    && *encoded_parent == (support::flip_node_side(encoded_from as usize) as u32) {
+                        // The first condition means that this is a bridge edge. The second
+                        // means that the edge is actually a bridge node in the bidirected graph.
+                        let node_index = support::node_side_id(encoded_from as usize);
+                        result.insert(component[node_index] as u32);
                 }
             }
         }
@@ -546,107 +562,89 @@ fn find_articulation_points(graph: &GBZ, component: &[usize]) -> HashSet<u32> {
     result
 }
 
-// Walks the chain from the start tip to the other tip, classifying links between nodes as simple or snarl.
-// Returns (chain_handles, is_snarl) where chain_handles are the oriented node visits.
-// is_snarl[i] indicates whether the link between chain_handles[i] and chain_handles[i+1] is a snarl.
+// Returns all handles in the top-level chain with `from_handle` and `to_handle` as the tips.
+// Also determines which handles are entry points to a snarl.
+// Returns `None` if there is no directed path between the tips.
 fn walk_chain(
     graph: &GBZ,
-    start_handle: u32,
-    chain_node_ids: &HashSet<u32>
-) -> (Vec<u32>, Vec<bool>) {
-    let mut chain_handles = Vec::with_capacity(chain_node_ids.len());
-    let mut is_snarl = Vec::with_capacity(chain_node_ids.len());
+    from_handle: usize, to_handle: usize,
+    bridges: &HashSet<u32>
+) -> Option<(Vec<u32>, Vec<bool>)> {
+    let shortest_path = shortest_unweighted_path(graph, from_handle, to_handle)?;
 
-    let mut current = start_handle;
-    chain_handles.push(current);
-
-    loop {
-        let cur_id = support::node_id(current as usize);
-        let cur_orient = support::node_orientation(current as usize);
-
-        let succs: Vec<(usize, Orientation)> = graph.successors(cur_id, cur_orient)
-            .map_or(Vec::new(), |iter| iter.collect());
-        if succs.is_empty() {
-            break;
-        }
-
-        // Check if this is a simple bridge edge: single successor with single predecessor.
-        if succs.len() == 1 {
-            let (next_id, next_o) = succs[0];
-            let next_handle = support::encode_node(next_id, next_o) as u32;
-            let pred_count = graph.predecessors(next_id, next_o)
-                .map_or(0, |iter: crate::gbz::EdgeIter<'_>| iter.len());
-            if pred_count == 1 {
-                is_snarl.push(false);
-                chain_handles.push(next_handle);
-                current = next_handle;
-                continue;
+    // If we visit a bridge node twice, it is a hairpin-like structure instead of
+    // a node in a top-level chain.
+    let mut visited_bridges = HashSet::new();
+    let mut duplicate_bridges = HashSet::new();
+    for &handle in shortest_path.iter() {
+        let node_id = support::node_id(handle as usize) as u32;
+        if bridges.contains(&node_id) {
+            let first_visit = visited_bridges.insert(node_id);
+            if !first_visit {
+                duplicate_bridges.insert(node_id);
             }
         }
-
-        // This is a snarl. BFS to find the next chain node where all paths converge.
-        let next_chain_handle = find_snarl_end(graph, current, chain_node_ids);
-        is_snarl.push(true);
-        chain_handles.push(next_chain_handle);
-        current = next_chain_handle;
     }
-    is_snarl.push(false); // We will reuse this vector to mark boundary nodes, so add a dummy value for the last node.
+    drop(visited_bridges);
 
-    // If we did not visit every tip and bridge node, the assumptions do not hold.
-    // Return empty vectors to skip this component.
-    if chain_handles.len() == chain_node_ids.len() {
-        (chain_handles, is_snarl)
-    } else {
-        (Vec::new(), Vec::new())
+    // Now determine the handles in the top-level chain and whether they are
+    // entry points to a snarl.
+    let mut chain_handles: Vec<u32> = Vec::new();
+    let mut is_snarl_entry: Vec<bool> = Vec::new();
+    for &handle in shortest_path.iter() {
+        let is_tip = handle == from_handle as u32 || handle == to_handle as u32;
+        let node_id = support::node_id(handle as usize) as u32;
+        let is_unique_bridge = bridges.contains(&node_id) && !duplicate_bridges.contains(&node_id);
+        if is_tip || is_unique_bridge {
+            chain_handles.push(handle);
+            let orientation = support::node_orientation(handle as usize);
+            let outdegree = graph.successors(node_id as usize, orientation)
+                .map_or(0, |iter| iter.count());
+            is_snarl_entry.push(outdegree > 1);
+        }
     }
+
+    Some((chain_handles, is_snarl_entry))
 }
 
-// BFS from the current handle's successors to find the next chain/tip node.
-fn find_snarl_end(
-    graph: &GBZ,
-    current_handle: u32,
-    chain_node_ids: &HashSet<u32>
-) -> u32 {
-    let cur_id = support::node_id(current_handle as usize);
-    let cur_orient = support::node_orientation(current_handle as usize);
-
+// Finds the shortest directed path between the given handles.
+// Each distance is 1 instead of the length of the node.
+fn shortest_unweighted_path(graph: &GBZ, start_handle: usize, end_handle: usize) -> Option<Vec<u32>> {
     let mut queue: VecDeque<u32> = VecDeque::new();
     let mut visited: HashSet<u32> = HashSet::new();
-    visited.insert(current_handle);
+    let mut parent: HashMap<u32, u32> = HashMap::new();
 
-    // Seed BFS with successors of the current handle.
-    if let Some(iter) = graph.successors(cur_id, cur_orient) {
-        for (next_id, next_o) in iter {
-            let next_handle = support::encode_node(next_id, next_o) as u32;
-            if !visited.contains(&next_handle) {
-                visited.insert(next_handle);
-                queue.push_back(next_handle);
-            }
-        }
-    }
+    visited.insert(start_handle as u32);
+    queue.push_back(start_handle as u32);
 
     while let Some(handle) = queue.pop_front() {
-        let h_id = support::node_id(handle as usize);
-        let h_orient = support::node_orientation(handle as usize);
-
-        // If this is a chain node (bridge or tip) different from current, it's our target.
-        if chain_node_ids.contains(&(h_id as u32)) && h_id != cur_id {
-            return handle;
+        if handle == end_handle as u32 {
+            // Reconstruct path.
+            let mut path = Vec::new();
+            let mut current = handle;
+            while current != start_handle as u32 {
+                path.push(current);
+                current = parent[&current];
+            }
+            path.push(start_handle as u32);
+            path.reverse();
+            return Some(path);
         }
 
-        if let Some(iter) = graph.successors(h_id, h_orient) {
+        let (node_id, orientation) = support::decode_node(handle as usize);
+        if let Some(iter) = graph.successors(node_id, orientation) {
             for (next_id, next_o) in iter {
                 let next_handle = support::encode_node(next_id, next_o) as u32;
                 if !visited.contains(&next_handle) {
                     visited.insert(next_handle);
+                    parent.insert(next_handle, handle);
                     queue.push_back(next_handle);
                 }
             }
         }
     }
 
-    // Should not reach here in a valid graph with exactly 2 tips.
-    current_handle
+    None
 }
 
 //-----------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::gbwt::builder::{GBWTBuilder, MutableGBWT};
 pub use crate::gbz::GBZ;
 pub use crate::sequences::Segment;
 pub use crate::metadata::{Metadata, MetadataBuilder, PathName, FullPathName};
-pub use crate::support::{GraphPosition, Orientation};
+pub use crate::support::{GraphPosition, Orientation, NodeSide};
 
 //-----------------------------------------------------------------------------
 

--- a/src/support.rs
+++ b/src/support.rs
@@ -58,6 +58,41 @@ impl fmt::Display for Orientation {
     }
 }
 
+/// Side of a node.
+///
+/// Some graph algorithms use combinations (node id, node side) as nodes.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NodeSide {
+    /// Left side.
+    ///
+    /// This is the entry side for [`Orientation::Forward`] and the exit side for [`Orientation::Reverse`].
+    Left = 0,
+    /// Right side.
+    ///
+    /// This is the exit side for [`Orientation::Forward`] and the entry side for [`Orientation::Reverse`].
+    Right = 1,
+}
+
+impl NodeSide {
+    /// Returns the other side.
+    #[inline]
+    pub fn flip(&self) -> NodeSide {
+        match *self {
+            Self::Left => Self::Right,
+            Self::Right => Self::Left,
+        }
+    }
+}
+
+impl fmt::Display for NodeSide {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NodeSide::Left => write!(f, "left"),
+            NodeSide::Right => write!(f, "right"),
+        }
+    }
+}
+
 /// Position in a bidirected sequence graph.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GraphPosition {
@@ -185,7 +220,7 @@ impl From<Run> for SmallRun {
 
 //-----------------------------------------------------------------------------
 
-/// Returns the GBWT node identifier corresponding to the given original node and orientation.
+/// Returns the GBWT node identifier (handle) corresponding to the given original node and orientation.
 ///
 /// This encoding is used in bidirectional GBWT indexes.
 ///
@@ -202,7 +237,7 @@ pub fn encode_node(id: usize, orientation: Orientation) -> usize {
     2 * id + (orientation as usize)
 }
 
-/// Returns the original node identifier corresponding to the given GBWT node.
+/// Returns the original node identifier corresponding to the given GBWT node (handle).
 ///
 /// This encoding is used in bidirectional GBWT indexes.
 #[inline]
@@ -210,7 +245,7 @@ pub fn node_id(id: usize) -> usize {
     id / 2
 }
 
-/// Returns the orientation of the original node corresponding to the given GBWT node.
+/// Returns the orientation of the original node corresponding to the given GBWT node (handle).
 ///
 /// This encoding is used in bidirectional GBWT indexes.
 #[inline]
@@ -221,18 +256,96 @@ pub fn node_orientation(id: usize) -> Orientation {
     }
 }
 
-/// Decodes a GBWT node identifier as a node identifier and orientation in the original graph.
+/// Decodes a GBWT node identifier (handle) as a node identifier and orientation in the original graph.
 #[inline]
 pub fn decode_node(id: usize) -> (usize, Orientation) {
     (node_id(id), node_orientation(id))
 }
 
-/// Returns the GBWT node identifier for the same original node in the other orientation.
+/// Returns the GBWT node identifier (handle) for the same original node in the other orientation.
 ///
 /// This encoding is used in bidirectional GBWT indexes.
 #[inline]
 pub fn flip_node(id: usize) -> usize {
     id ^ 1
+}
+
+/// Returns the encoded node side corresponding to the given original node and node side.
+///
+/// # Arguments
+///
+/// * `id`: Identifier of the original node.
+/// * `side`: Side of the node.
+///
+/// # Panics
+///
+/// May panic if `id > usize::MAX / 2`.
+#[inline]
+pub fn encode_node_side(id: usize, side: NodeSide) -> usize {
+    2 * id + (side as usize)
+}
+
+/// Returns the original node identifier corresponding to the given encoded node side.
+#[inline]
+pub fn node_side_id(id: usize) -> usize {
+    id / 2
+}
+
+/// Returns the node side corresponding to the given encoded node side.
+#[inline]
+pub fn node_side(id: usize) -> NodeSide {
+    match id & 1 {
+        0 => NodeSide::Left,
+        _ => NodeSide::Right,
+    }
+}
+
+/// Decodes an encoded node side as a node identifier and node side in the original graph.
+#[inline]
+pub fn decode_node_side(id: usize) -> (usize, NodeSide) {
+    (node_side_id(id), node_side(id))
+}
+
+/// Returns the encoded node side for the other side of the same original node.
+#[inline]
+pub fn flip_node_side(id: usize) -> usize {
+    id ^ 1
+}
+
+/// Returns the entry side of the given orientation.
+#[inline]
+pub fn entry_side(orientation: Orientation) -> NodeSide {
+    match orientation {
+        Orientation::Forward => NodeSide::Left,
+        Orientation::Reverse => NodeSide::Right,
+    }
+}
+
+/// Returns the exit side of the given orientation.
+#[inline]
+pub fn exit_side(orientation: Orientation) -> NodeSide {
+    match orientation {
+        Orientation::Forward => NodeSide::Right,
+        Orientation::Reverse => NodeSide::Left,
+    }
+}
+
+/// Returns the orientation corresponding to the given entry side.
+#[inline]
+pub fn entry_orientation(side: NodeSide) -> Orientation {
+    match side {
+        NodeSide::Left => Orientation::Forward,
+        NodeSide::Right => Orientation::Reverse,
+    }
+}
+
+/// Returns the orientation corresponding to the given exit side.
+#[inline]
+pub fn exit_orientation(side: NodeSide) -> Orientation {
+    match side {
+        NodeSide::Left => Orientation::Reverse,
+        NodeSide::Right => Orientation::Forward,
+    }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
It turns out Claude did not really understand bidirected sequence graphs. The `find_chains` algorithm worked with all the test cases but failed with the weirder structures found in whole-genome graphs. This should fix the algorithm.