### PR TITLE
GBZ: add gbwt() accessor to expose the underlying GBWT index

### DIFF
--- a/src/gbz.rs
+++ b/src/gbz.rs
@@ -144,6 +144,11 @@ impl GBZ {
         &mut self.tags
     }
 
+    /// Returns a reference to the underlying GBWT index.
+    pub fn gbwt(&self) -> &GBWT {
+        &self.index
+    }
+
     // Internal method that returns a list of potential reference sample names.
     // Includes the generic sample [`GENERIC_SAMPLE`] if `also_generic` is `true`.
     fn reference_samples_impl(&self, also_generic: bool) -> Vec<String> {


### PR DESCRIPTION
This adds a simple public accessor to GBZ:

```rust
pub fn gbwt(&self) -> &GBWT {
    &self.index
}
```

GBWT has a backward(pos: Pos) -> Option<Pos> method that is useful for walking a path in reverse. Currently, this is unreachable from a &GBZ reference because index is a private field with no public accessor.

The use case is finding the boundary nodes of a snarl that encloses a query interval. I need to walk the path backward from the interval start until I hit a chain boundary node. Without access to GBWT::backward(), the only alternative is a forward scan from path index samples, which requires iterating over multiple samples for large snarls.