### PR TITLE
headers: use u64 (not usize) in Payload structs for wasm32 compatibility

### DIFF
--- a/src/gbwt.rs
+++ b/src/gbwt.rs
@@ -108,7 +108,7 @@ impl GBWT {
     /// Returns the total length of the sequences in the index.
     #[inline]
     pub fn len(&self) -> usize {
-        self.header.payload().size
+        self.header.payload().size as usize
     }
 
     /// Returns `true` if the index is empty.
@@ -120,19 +120,19 @@ impl GBWT {
     /// Returns the number of sequences in the index.
     #[inline]
     pub fn sequences(&self) -> usize {
-        self.header.payload().sequences
+        self.header.payload().sequences as usize
     }
 
     /// Returns the size of the alphabet.
     #[inline]
     pub fn alphabet_size(&self) -> usize {
-        self.header.payload().alphabet_size
+        self.header.payload().alphabet_size as usize
     }
 
     /// Returns the alphabet offset for the effective alphabet.
     #[inline]
     pub fn alphabet_offset(&self) -> usize {
-        self.header.payload().offset
+        self.header.payload().offset as usize
     }
 
     /// Returns the size of the effective alphabet.
@@ -424,7 +424,7 @@ impl Serialize for GBWT {
             return Err(Error::new(ErrorKind::InvalidData, "GBWT: Invalid metadata flag in the header"));
         }
         if let Some(meta) = metadata.as_ref() && meta.has_path_names() {
-            let expected = if header.is_set(GBWTPayload::FLAG_BIDIRECTIONAL) { header.payload().sequences / 2 } else { header.payload().sequences };
+            let expected = if header.is_set(GBWTPayload::FLAG_BIDIRECTIONAL) { (header.payload().sequences / 2) as usize } else { header.payload().sequences as usize };
             if meta.paths() > 0 && meta.paths() != expected {
                 return Err(Error::new(ErrorKind::InvalidData, "GBWT: Invalid path count in the metadata"));
             }

--- a/src/gbwt/builder.rs
+++ b/src/gbwt/builder.rs
@@ -859,13 +859,13 @@ impl From<MutableGBWT> for GBWT {
         if builder.has_metadata() {
             header.set(GBWTPayload::FLAG_METADATA);
         }
-        header.payload_mut().sequences = builder.sequences();
-        header.payload_mut().size = builder.len();
+        header.payload_mut().sequences = builder.sequences() as u64;
+        header.payload_mut().size = builder.len() as u64;
         if let Some(min_node) = builder.min_node() {
-            header.payload_mut().offset = min_node - 1;
+            header.payload_mut().offset = (min_node - 1) as u64;
         }
         if let Some(max_node) = builder.max_node() {
-            header.payload_mut().alphabet_size = max_node + 1;
+            header.payload_mut().alphabet_size = (max_node + 1) as u64;
         } else if !builder.is_empty() {
             // Special case when we have only empty sequences.
             header.payload_mut().alphabet_size = 1;
@@ -873,7 +873,7 @@ impl From<MutableGBWT> for GBWT {
 
         // Encode the BWT, including the endmarker record.
         let mut bwt_builder = BWTBuilder::new(&builder.endmarker_edges, &builder.endmarker);
-        for node_id in (header.payload().offset + 1)..header.payload().alphabet_size {
+        for node_id in (header.payload().offset as usize + 1)..header.payload().alphabet_size as usize {
             if let Some(record) = builder.records[node_id - builder.first_node].as_ref() {
                 bwt_builder.append(&record.outgoing, record.bwt.iter().map(|&run| Run::from(run)));
             } else {

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -185,20 +185,26 @@ pub trait Payload: Copy + Eq + Default {
 //-----------------------------------------------------------------------------
 
 /// Payload for the GBWT header.
+///
+/// Fields are `u64` rather than `usize` so the `#[repr(C)]` on-disk layout is
+/// identical on 32-bit and 64-bit targets. `Header<T>: Serializable` writes
+/// the payload as a raw `mem::size_of` byte copy; if any field were `usize`,
+/// a 32-bit consumer (e.g. `wasm32`) would misread payloads written on a
+/// 64-bit host. Accessors elsewhere cast to/from `usize` at the boundary.
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct GBWTPayload {
     /// Number of sequences in the GBWT.
-    pub sequences: usize,
+    pub sequences: u64,
 
     /// Total length of the sequences, including the endmarkers.
-    pub size: usize,
+    pub size: u64,
 
     /// Alphabet offset: node identifiers in `1..offset + 1` are not used.
-    pub offset: usize,
+    pub offset: u64,
 
     /// Alphabet size: all node identifiers are in `1..alphabet_size`.
-    pub alphabet_size: usize,
+    pub alphabet_size: u64,
 }
 
 impl GBWTPayload {
@@ -236,17 +242,20 @@ impl Payload for GBWTPayload {
 //-----------------------------------------------------------------------------
 
 /// Payload for the GBWT metadata header.
+///
+/// See `GBWTPayload` — `u64` fields keep the `#[repr(C)]` on-disk layout
+/// portable across 32-bit and 64-bit targets.
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct MetadataPayload {
     /// Number of samples in the GBWT.
-    pub sample_count: usize,
+    pub sample_count: u64,
 
     /// Number of haplotypes in the GBWT.
-    pub haplotype_count: usize,
+    pub haplotype_count: u64,
 
     /// Number of contigs in the graph.
-    pub contig_count: usize,
+    pub contig_count: u64,
 }
 
 impl MetadataPayload {
@@ -281,11 +290,14 @@ impl Payload for MetadataPayload {
 //-----------------------------------------------------------------------------
 
 /// Payload for the GBWTGraph header.
+///
+/// See `GBWTPayload` — `u64` fields keep the `#[repr(C)]` on-disk layout
+/// portable across 32-bit and 64-bit targets.
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct SequencesPayload {
     /// Number of nodes in the original graph.
-    pub nodes: usize,
+    pub nodes: u64,
 }
 
 impl SequencesPayload {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -184,14 +184,14 @@ impl Metadata {
 
     /// Returns the number samples.
     pub fn samples(&self) -> usize {
-        self.header.payload().sample_count
+        self.header.payload().sample_count as usize
     }
 
     /// Returns the number of haplotypes.
     ///
     /// This generally corresponds to the number of full-length paths in a graph component.
     pub fn haplotypes(&self) -> usize {
-        self.header.payload().haplotype_count
+        self.header.payload().haplotype_count as usize
     }
 
     /// Returns the name of the sample with the given identifier, or [`None`] if there is no such sample or name.
@@ -239,7 +239,7 @@ impl Metadata {
     ///
     /// A contig usually corresponds to a graph component.
     pub fn contigs(&self) -> usize {
-        self.header.payload().contig_count
+        self.header.payload().contig_count as usize
     }
 
     /// Returns the name of the contig with the given identifier, or [`None`] if there is no such contig or name.
@@ -313,7 +313,7 @@ impl Serialize for Metadata {
 
         let sample_names = Dictionary::load(reader)?;
         if header.is_set(MetadataPayload::FLAG_SAMPLE_NAMES) {
-            if header.payload().sample_count != sample_names.len() {
+            if header.payload().sample_count as usize != sample_names.len() {
                 return Err(Error::new(ErrorKind::InvalidData, "Metadata: Sample count does not match the number of sample names"));
             }
         } else if !sample_names.is_empty() {
@@ -322,7 +322,7 @@ impl Serialize for Metadata {
 
         let contig_names = Dictionary::load(reader)?;
         if header.is_set(MetadataPayload::FLAG_CONTIG_NAMES) {
-            if header.payload().contig_count != contig_names.len() {
+            if header.payload().contig_count as usize != contig_names.len() {
                 return Err(Error::new(ErrorKind::InvalidData, "Metadata: Contig count does not match the number of contig names"));
             }
         } else if !contig_names.is_empty() {
@@ -355,9 +355,9 @@ impl Serialize for Metadata {
 impl From<MetadataBuilder> for Metadata {
     fn from(builder: MetadataBuilder) -> Self {
         let mut header = Header::<MetadataPayload>::default();
-        header.payload_mut().sample_count = builder.sample_names.len();
-        header.payload_mut().contig_count = builder.contig_names.len();
-        header.payload_mut().haplotype_count = builder.haplotypes.len();
+        header.payload_mut().sample_count = builder.sample_names.len() as u64;
+        header.payload_mut().contig_count = builder.contig_names.len() as u64;
+        header.payload_mut().haplotype_count = builder.haplotypes.len() as u64;
         header.set(MetadataPayload::FLAG_PATH_NAMES);
         header.set(MetadataPayload::FLAG_SAMPLE_NAMES);
         header.set(MetadataPayload::FLAG_CONTIG_NAMES);

--- a/src/metadata/tests.rs
+++ b/src/metadata/tests.rs
@@ -15,9 +15,9 @@ const PHASES: usize = 2;
 
 fn create_metadata(paths: bool, samples: bool, contigs: bool) -> Metadata {
     let mut header = Header::<MetadataPayload>::new();
-    header.payload_mut().sample_count = SAMPLES;
-    header.payload_mut().haplotype_count = SAMPLES * PHASES;
-    header.payload_mut().contig_count = CONTIGS;
+    header.payload_mut().sample_count = SAMPLES as u64;
+    header.payload_mut().haplotype_count = (SAMPLES * PHASES) as u64;
+    header.payload_mut().contig_count = CONTIGS as u64;
 
     let mut path_names = Vec::<PathName>::new();
     if paths {

--- a/src/sequences.rs
+++ b/src/sequences.rs
@@ -97,7 +97,7 @@ impl Sequences {
     /// This may be less than the number of sequences, if there are gaps in the node id space.
     #[inline]
     pub fn nodes(&self) -> usize {
-        self.header.payload().nodes
+        self.header.payload().nodes as usize
     }
 
     /// Returns the number of sequences in the graph.
@@ -315,7 +315,7 @@ impl Serialize for Sequences {
         if header.is_set(SequencesPayload::FLAG_TRANSLATION) {
             // If there are no gaps in the node id space, `mapping.len() == header.payload().nodes + 1`.
             // Unused nodes create gaps.
-            if mapping.len() <= header.payload().nodes {
+            if mapping.len() <= header.payload().nodes as usize {
                 return Err(Error::new(ErrorKind::InvalidData, "Sequences: Node-to-segment mapping does not match the number of nodes"));
             }
             if mapping.len() != sequences.len() + 1 {


### PR DESCRIPTION
Hi there,
I just attended mempang26 conference (fun:) and had a hackathon project working on using gbz-base in sequencetubemap via wasm. I targetted this because I was interested in pure-client side solutions and the gbz-base concept i think lends itself to this

I saw that gbz-base was actively being developed so wanted to contribute a potential fix where on my machine files generated by gbz-base didn't work in wasm I think due to usize usage, since wasm thought usize is 4 bytes instead of 8. making it u64  makes it a consistent data format size

Disclaimer: i used AI (claude code) to generate this code. I am not sure if all the as usize are valid or good casts. there is another one in gbwt-rs also


