### PR TITLE
Graph names

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,7 @@
 
 * Supports `GBZ` version 3 and `GBWT` version 6 with Zstandard compression for the BWT.
 * Implements `SerializeVersion` trait for serializing different versions of `GBZ`, `GBWT`, and `Sequences`.
+* `GraphName` structure for representing graph names and relationships between graphs (imported from [pggname](https://github.com/jltsiren/pggname)).
 
 ## GBZ 0.6.2 (2026-08-11)
 
@@ -98,7 +99,7 @@ The first pre-release includes supports the GBWT Simple-SDS file format as well 
 * Update version in `Cargo.toml`.
 * Switch to crates.io versions of dependencies, if necessary.
 * Update `RELEASES.md`.
-* Run `cargo clippy --features=binaries`.
+* Run `cargo clippy --features binaries`.
 * Run tests with `cargo test` and `cargo test -- --ignored`.
 * Build documentation with `cargo doc`.
 * Build the optimized version with `cargo build --release --features binaries`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,9 @@
 
 * Supports `GBZ` version 3 and `GBWT` version 6 with Zstandard compression for the BWT.
 * Implements `SerializeVersion` trait for serializing different versions of `GBZ`, `GBWT`, and `Sequences`.
-* `GraphName` structure for representing graph names and relationships between graphs (imported from [pggname](https://github.com/jltsiren/pggname)).
+* `GraphName` structure for representing graph names and relationships between graphs.
+  * Imported from [pggname](https://github.com/jltsiren/pggname).
+  * `gbunzip` now includes graph name information in GFA headers.
 
 ## GBZ 0.6.2 (2026-08-11)
 

--- a/src/bin/gbunzip.rs
+++ b/src/bin/gbunzip.rs
@@ -3,7 +3,7 @@
     clippy::new_without_default
 )]
 
-use gbz::{GBWT, GBZ, Orientation};
+use gbz::{GBWT, GBZ, GraphName, Orientation};
 use gbz::{GENERIC_SAMPLE, REFERENCE_SAMPLES_KEY};
 use gbz::internal;
 
@@ -192,21 +192,35 @@ fn write_gfa(gbz: &GBZ, config: &Config) -> io::Result<()> {
 
 fn write_gfa_header<T: Write>(gbz: &GBZ, output: &mut T) -> io::Result<()> {
     let index: &GBWT = gbz.as_ref();
-    let tags = index.tags();
-    let header = if let Some(sample_names) = tags.get(REFERENCE_SAMPLES_KEY) {
+    let gbwt_tags = index.tags();
+    let header = if let Some(sample_names) = gbwt_tags.get(REFERENCE_SAMPLES_KEY) {
         format!("H\tVN:Z:1.1\tRS:Z:{}\n", sample_names)
     } else {
         "H\tVN:Z:1.1\n".to_string()
     };
     output.write_all(header.as_ref())?;
+
+    let gbz_tags = gbz.tags();
+    let graph_name = GraphName::from_tags(&gbz_tags);
+    match graph_name {
+        Ok(graph_name) => {
+            let header_lines = graph_name.to_gfa_header_lines();
+            for line in header_lines {
+                output.write_all(line.as_bytes())?;
+                output.write_all(b"\n")?;
+            }
+        },
+        Err(err) => {
+            eprintln!("Warning: Could not parse graph name tags: {}", err);
+        },
+    }
+
     Ok(())
 }
 
 fn write_gfa_impl<T: Write + Send>(gbz: &GBZ, output: T, config: &Config) -> io::Result<()> {
     let mut buffer = BufWriter::with_capacity(config.buffer_size, output);
     write_gfa_header(gbz, &mut buffer)?;
-    // FIXME: We should output pggname information, but that functionality is currently
-    // in a separate crate that depends on gbz.
     write_segments(gbz, &mut buffer, config)?;
     write_links(gbz, &mut buffer, config)?;
 
@@ -348,7 +362,6 @@ fn write_paths<T: Write + Send>(gbz: &GBZ, output: &mut T, config: &Config) -> i
     let metadata = gbz.metadata().unwrap();
     let ref_sample = metadata.sample_id(GENERIC_SAMPLE);
     if ref_sample.is_none() {
-        eprintln!("No generic paths in the graph");
         return Ok(());
     }
     let ref_sample = ref_sample.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod gbz;
 pub mod sequences;
 pub mod headers;
 pub mod metadata;
+pub mod name;
 pub mod support;
 
 // Shared internal code for the binaries.
@@ -61,7 +62,8 @@ pub use crate::gbwt::builder::{GBWTBuilder, MutableGBWT};
 pub use crate::gbz::GBZ;
 pub use crate::sequences::Segment;
 pub use crate::metadata::{Metadata, MetadataBuilder, PathName, FullPathName};
-pub use crate::support::{GraphPosition, Orientation, NodeSide};
+pub use crate::name::GraphName;
+pub use crate::support::{GraphPosition, Orientation, NodeSide, Tags};
 
 //-----------------------------------------------------------------------------
 

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,0 +1,624 @@
+//! Structures for storing graph name and relationship information.
+//!
+//! A [`GraphName`] can store a graph name along with subgraph and translation relationships between graphs.
+//! This information can be imported from and exported to [`Tags`] objects as well as GFA and GAF header lines.
+//!
+//! These structures were originally designed for use with stable [pggname](https://github.com/jltsiren/pggname) graph names.
+//! They can also be used with other naming schemes.
+//! The GFA representation in optional fields of type `Z` restricts the names to printable ASCII, including space.
+//! Since commas (`,`) and semicolons (`;`) are used as separators, they are not allowed in graph names.
+//!
+//! Graph A is a subgraph of graph B, if all nodes and edges of A are also present in B.
+//! The node identifiers and sequence labels in graph A must match those in graph B.
+//! This usually means that anything using graph A as a reference can also use graph B.
+//!
+//! For coordinate translation from graph A to graph B, we use an intermediate graph C that is a subgraph of B.
+//! We require that graphs A and C are isomorphic (with matching node labels), if we break their nodes into 1 bp pieces.
+//! There is therefore a one-to-one mapping between unary paths in A and C.
+//! We can use this mapping to translate positions in graph A to graph C, and then use these positions in graph B.
+
+use crate::{GBZ, Tags};
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+#[cfg(test)]
+mod tests;
+
+//-----------------------------------------------------------------------------
+
+/// A structure that stores a graph name along with subgraph and translation relationships between graphs.
+///
+/// Each object corresponds to a particular graph.
+/// The object may store the name of the graph, if available.
+/// It may contain the relationship between this graph and its parent graph, if the relationship and the parent's name are known.
+/// There may also be other relationships inherited from the parent graph.
+///
+/// # Examples
+///
+/// ```
+/// use gbz::GraphName;
+///
+/// let parent = GraphName::new(String::from("parent"));
+/// let mut translated = GraphName::new(String::from("translated"));
+/// translated.add_translation_to(&parent);
+/// let mut subgraph = GraphName::new(String::from("subgraph"));
+/// subgraph.make_subgraph_of(&translated);
+///
+/// assert!(subgraph.is_subgraph_of(&translated));
+/// assert!(!subgraph.is_subgraph_of(&parent));
+/// assert!(translated.translates_to(&parent));
+/// assert!(subgraph.translates_to(&parent));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GraphName {
+    name: Option<String>,
+    subgraph: BTreeMap<String, BTreeSet<String>>,
+    translation: BTreeMap<String, BTreeSet<String>>,
+}
+
+/// Constants.
+impl GraphName {
+    /// Name of the [`Tags`] key storing the graph name.
+    const TAG_NAME: &'static str = "pggname";
+
+    /// Name of the [`Tags`] key storing subgraph relationships.
+    const TAG_SUBGRAPH: &'static str = "subgraph";
+
+    /// Name of the [`Tags`] key storing translation relationships.
+    const TAG_TRANSLATION: &'static str = "translation";
+
+    /// GFA header tag storing the graph name.
+    const GFA_HEADER_NAME: &'static str = "NM";
+
+    /// GAF header tag storing the graph name.
+    const GAF_HEADER_NAME: &'static str = "RN";
+
+    /// GFA/GAF header tag storing subgraph relationships.
+    const GFA_GAF_HEADER_SUBGRAPH: &'static str = "SG";
+
+    /// GFA/GAF header tag storing translation relationships.
+    const GFA_GAF_HEADER_TRANSLATION: &'static str = "TL";
+
+    const GFA_HEADER_TYPE: &'static str = "H";
+    const GAF_HEADER_PREFIX: &'static str = "@"; 
+    const GFA_GAF_FIELD_SEPARATOR: char = '\t';
+    const TAG_GFA_RELATIONSHIP_SEPARATOR: char = ',';
+    const TAG_RELATIONSHIP_LIST_SEPARATOR: char = ';';
+}
+
+//-----------------------------------------------------------------------------
+
+/// Construction.
+impl GraphName {
+    /// Creates a new `GraphName` with the given graph name.
+    pub fn new(name: String) -> Self {
+        GraphName {
+            name: Some(name),
+            subgraph: BTreeMap::new(),
+            translation: BTreeMap::new(),
+        }
+    }
+
+    /// Parses a `GraphName` from the given tags.
+    ///
+    /// Returns an error if tag values are malformed.
+    pub fn from_tags(tags: &Tags) -> Result<Self, String> {
+        let mut result = GraphName::default();
+
+        if let Some(name_field) = tags.get(Self::TAG_NAME) {
+            result.name = Some(String::from(name_field));
+        }
+
+        if let Some(subgraph_field) = tags.get(Self::TAG_SUBGRAPH) {
+            let relationships: Vec<&str> = subgraph_field.split(Self::TAG_RELATIONSHIP_LIST_SEPARATOR).collect();
+            for rel in relationships {
+                let parts: Vec<&str> = rel.split(Self::TAG_GFA_RELATIONSHIP_SEPARATOR).collect();
+                if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+                    return Err(format!("Invalid subgraph relationship: {}", rel));
+                }
+                result.subgraph
+                    .entry(String::from(parts[0]))
+                    .or_default()
+                    .insert(String::from(parts[1]));
+            }
+        }
+
+        if let Some(translation_field) = tags.get(Self::TAG_TRANSLATION) {
+            let relationships: Vec<&str> = translation_field.split(Self::TAG_RELATIONSHIP_LIST_SEPARATOR).collect();
+            for rel in relationships {
+                let parts: Vec<&str> = rel.split(Self::TAG_GFA_RELATIONSHIP_SEPARATOR).collect();
+                if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+                    return Err(format!("Invalid translation relationship: {}", rel));
+                }
+                result.translation
+                    .entry(String::from(parts[0]))
+                    .or_default()
+                    .insert(String::from(parts[1]));
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Parses a `GraphName` from the tags in the given GBZ graph.
+    ///
+    /// Returns an empty object if the tags cannot be parsed.
+    pub fn from_gbz(gbz: &GBZ) -> Self {
+        Self::from_tags(gbz.tags()).unwrap_or_default()
+    }
+
+    fn typed_field_is_string(field: &str) -> Result<bool, String> {
+        let bytes = field.as_bytes();
+        if field.len() < 5 || bytes[2] != b':' || bytes[4] != b':' {
+            return Err(format!("Invalid GFA typed field: {}", field));
+        }
+        Ok(bytes[3] == b'Z')
+    }
+
+    fn parse_gfa_optional_fields(fields: &[&str], result: &mut GraphName) -> Result<(), String> {
+        for &field in fields {
+            if !Self::typed_field_is_string(field)? {
+                continue;
+            }
+            let tag = &field[0..2];
+            let value = &field[5..];
+            match tag {
+                Self::GFA_HEADER_NAME => {
+                    result.name = Some(String::from(value));
+                }
+                Self::GFA_GAF_HEADER_SUBGRAPH => {
+                    let parts: Vec<&str> = value.split(Self::TAG_GFA_RELATIONSHIP_SEPARATOR).collect();
+                    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+                        return Err(format!("Invalid subgraph field: {}", field));
+                    }
+                    result.subgraph
+                        .entry(String::from(parts[0]))
+                        .or_default()
+                        .insert(String::from(parts[1]));
+                }
+                Self::GFA_GAF_HEADER_TRANSLATION => {
+                    let parts: Vec<&str> = value.split(Self::TAG_GFA_RELATIONSHIP_SEPARATOR).collect();
+                    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+                        return Err(format!("Invalid translation field: {}", field));
+                    }
+                    result.translation
+                        .entry(String::from(parts[0]))
+                        .or_default()
+                        .insert(String::from(parts[1]));
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_gaf_header_fields(line: &str, fields: &[&str], result: &mut GraphName) -> Result<(), String> {
+        match &fields[0][1..] {
+            Self::GAF_HEADER_NAME => {
+                if fields.len() != 2 || fields[1].is_empty() {
+                    return Err(format!("Invalid GAF name header line: {}", line));
+                }
+                result.name = Some(String::from(fields[1]));
+            }
+            Self::GFA_GAF_HEADER_SUBGRAPH => {
+                if fields.len() != 3 || fields[1].is_empty() || fields[2].is_empty() {
+                    return Err(format!("Invalid GAF subgraph header line: {}", line));
+                }
+                result.subgraph
+                    .entry(String::from(fields[1]))
+                    .or_default()
+                    .insert(String::from(fields[2]));
+            }
+            Self::GFA_GAF_HEADER_TRANSLATION => {
+                if fields.len() != 3 || fields[1].is_empty() || fields[2].is_empty() {
+                    return Err(format!("Invalid GAF translation header line: {}", line));
+                }
+                result.translation
+                    .entry(String::from(fields[1]))
+                    .or_default()
+                    .insert(String::from(fields[2]));
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Parses a `GraphName` from the given GFA/GAF header lines.
+    ///
+    /// The lines must not end with a newline.
+    /// Returns an error if the lines cannot be parsed.
+    pub fn from_header_lines(lines: &[String]) -> Result<Self, String> {
+        let mut result = GraphName::default();
+
+        for (i, line) in lines.iter().enumerate() {
+            let fields: Vec<&str> = line.split(Self::GFA_GAF_FIELD_SEPARATOR).collect();
+            if fields.len() < 2 {
+                return Err(format!("Error parsing header line {}: not enough fields", i + 1));
+            }
+            if fields[0] == Self::GFA_HEADER_TYPE {
+                Self::parse_gfa_optional_fields(&fields[1..], &mut result)?;
+            } else if fields[0].len() == 3 && fields[0].starts_with(Self::GAF_HEADER_PREFIX) {
+                Self::parse_gaf_header_fields(line, &fields, &mut result)?;
+            } else {
+                return Err(format!("Error parsing header line {}: unknown first field {}", i + 1, fields[0]));
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Adds a new subgraph relationship, if both names are non-empty.
+    pub fn add_subgraph(&mut self, subgraph: &str, supergraph: &str) {
+        if !subgraph.is_empty() && !supergraph.is_empty() {
+            self.subgraph
+                .entry(String::from(subgraph))
+                .or_default()
+                .insert(String::from(supergraph));
+        }
+    }
+
+    /// Adds a new subgraph relationship between this graph and the parent graph.
+    ///
+    /// Also copies all relationships from the parent graph.
+    /// Does nothing if either name is not available.
+    pub fn make_subgraph_of(&mut self, parent: &GraphName) {
+        if !self.has_name() || !parent.has_name() {
+            return;
+        }
+        let entry = self.subgraph.entry(self.name.as_ref().unwrap().clone()).or_default();
+        entry.insert(parent.name.as_ref().unwrap().clone());
+        self.add_relationships(parent);
+    }
+
+    /// Adds a new translation relationship, if both names are non-empty.
+    pub fn add_translation(&mut self, from: &str, to: &str) {
+        if !from.is_empty() && !to.is_empty() {
+            self.translation
+                .entry(String::from(from))
+                .or_default()
+                .insert(String::from(to));
+        }
+    }
+
+    /// Adds a new translation relationship between this graph and the parent graph.
+    ///
+    /// Also copies all relationships from the parent graph.
+    /// Does nothing if either name is not available.
+    pub fn add_translation_to(&mut self, parent: &GraphName) {
+        if !self.has_name() || !parent.has_name() {
+            return;
+        }
+        let entry = self.translation.entry(self.name.as_ref().unwrap().clone()).or_default();
+        entry.insert(parent.name.as_ref().unwrap().clone());
+        self.add_relationships(parent);
+    }
+
+    /// Adds all relationships from another `GraphName` object.
+    pub fn add_relationships(&mut self, other: &GraphName) {
+        for (supergraph, subgraphs) in &other.subgraph {
+            let entry = self.subgraph.entry(supergraph.clone()).or_default();
+            for subgraph in subgraphs {
+                entry.insert(subgraph.clone());
+            }
+        }
+        for (from, tos) in &other.translation {
+            let entry = self.translation.entry(from.clone()).or_default();
+            for to in tos {
+                entry.insert(to.clone());
+            }
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+/// Export to other formats.
+impl GraphName {
+    fn relationships_to_string(relationships: &BTreeMap<String, BTreeSet<String>>) -> String {
+        let mut value = String::new();
+        for (from, tos) in relationships {
+            for to in tos {
+                if !value.is_empty() {
+                    value.push(Self::TAG_RELATIONSHIP_LIST_SEPARATOR);
+                }
+                value.push_str(from);
+                value.push(Self::TAG_GFA_RELATIONSHIP_SEPARATOR);
+                value.push_str(to);
+            }
+        }
+        value
+    }
+
+    /// Writes the data stored in this object to the given tags.
+    ///
+    /// Clears existing tags if no corresponding data is available.
+    pub fn set_tags(&self, tags: &mut Tags) {
+        if let Some(name) = &self.name {
+            tags.insert(Self::TAG_NAME, name);
+        } else {
+            tags.remove(Self::TAG_NAME);
+        }
+
+        if !self.subgraph.is_empty() {
+            let value = Self::relationships_to_string(&self.subgraph);
+            tags.insert(Self::TAG_SUBGRAPH, &value);
+        } else {
+            tags.remove(Self::TAG_SUBGRAPH);
+        }
+
+        if !self.translation.is_empty() {
+            let value = Self::relationships_to_string(&self.translation);
+            tags.insert(Self::TAG_TRANSLATION, &value);
+        } else {
+            tags.remove(Self::TAG_TRANSLATION);
+        }
+    }
+
+    /// Returns GFA header lines representing this object.
+    ///
+    /// The lines do not end with a newline.
+    pub fn to_gfa_header_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        if let Some(name) = &self.name {
+            lines.push(format!("H\t{}:Z:{}", Self::GFA_HEADER_NAME, name));
+        }
+        for (subgraph, supergraphs) in &self.subgraph {
+            for supergraph in supergraphs {
+                lines.push(format!("H\t{}:Z:{},{}", Self::GFA_GAF_HEADER_SUBGRAPH, subgraph, supergraph));
+            }
+        }
+        for (from, tos) in &self.translation {
+            for to in tos {
+                lines.push(format!("H\t{}:Z:{},{}", Self::GFA_GAF_HEADER_TRANSLATION, from, to));
+            }
+        }
+        lines
+    }
+
+    /// Returns GAF header lines representing this object.
+    ///
+    /// The lines do not end with a newline.
+    pub fn to_gaf_header_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        if let Some(name) = &self.name {
+            lines.push(format!("@{}\t{}", Self::GAF_HEADER_NAME, name));
+        }
+        for (subgraph, supergraphs) in &self.subgraph {
+            for supergraph in supergraphs {
+                lines.push(format!("@{}\t{}\t{}", Self::GFA_GAF_HEADER_SUBGRAPH, subgraph, supergraph));
+            }
+        }
+        for (from, tos) in &self.translation {
+            for to in tos {
+                lines.push(format!("@{}\t{}\t{}", Self::GFA_GAF_HEADER_TRANSLATION, from, to));
+            }
+        }
+        lines
+    }
+}
+
+/// Queries and operations.
+impl GraphName {
+    /// Returns the name of the graph, if available.
+    pub fn name(&self) -> Option<&String> {
+        self.name.as_ref()
+    }
+
+    /// Returns `true` if the graph has a name.
+    pub fn has_name(&self) -> bool {
+        self.name.is_some()
+    }
+
+    /// Returns `true` if both objects represent the same graph.
+    pub fn is_same(&self, other: &GraphName) -> bool {
+        match (&self.name, &other.name) {
+            (Some(name1), Some(name2)) => name1 == name2,
+            _ => false,
+        }
+    }
+
+    /// Returns an iterator over stored subgraph relationships.
+    ///
+    /// The iterator yields pairs `(subgraph_name, supergraph_name)` in sorted order.
+    pub fn subgraph_iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.subgraph.iter().flat_map(|(subgraph, supergraphs)| {
+            supergraphs.iter().map(move |supergraph| (subgraph.as_ref(), supergraph.as_ref()))
+        })
+    }
+
+    /// Returns an iterator over stored translation relationships.
+    ///
+    /// The iterator yields pairs `(from_name, to_name)` in sorted order.
+    pub fn translation_iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.translation.iter().flat_map(|(from, tos)| {
+            tos.iter().map(move |to| (from.as_ref(), to.as_ref()))
+        })
+    }
+
+    // Finds a path of subgraph relationships from `from` to `to`, including both.
+    // Uses relationships stored in `self`.
+    fn find_subgraph_path(&self, from: &GraphName, to: &GraphName) -> Option<Vec<String>> {
+        if !from.has_name() || !to.has_name() {
+            return None;
+        }
+        let from_name = from.name().unwrap();
+        let to_name = to.name().unwrap();
+
+        // Find a shortest path using BFS.
+        let mut predecessor: BTreeMap<String, String> = BTreeMap::new();
+        predecessor.insert(from_name.clone(), String::new());
+        let mut queue: VecDeque<String> = VecDeque::new();
+        queue.push_back(from_name.clone());
+        while let Some(curr) = queue.pop_front() {
+            if curr == *to_name {
+                break;
+            }
+            if let Some(supers) = self.subgraph.get(&curr) {
+                for supergraph in supers {
+                    if !predecessor.contains_key(supergraph) {
+                        predecessor.insert(supergraph.clone(), curr.clone());
+                        queue.push_back(supergraph.clone());
+                    }
+                }
+            }
+        }
+        if !predecessor.contains_key(to_name) {
+            return None;
+        }
+
+        // Trace back the path.
+        let mut result: Vec<String> = Vec::new();
+        let mut current = to_name.clone();
+        while !current.is_empty() {
+            result.push(current.clone());
+            current = predecessor.get(&current).unwrap().clone();
+        }
+        result.reverse();
+
+        Some(result)
+    }
+
+    // Finds a path of subgraph or translation relationships from `from` to `to`, including both.
+    // Each step is a pair `(name, is_translation)`, where `is_translation` indicates whether the step to the next name is a translation.
+    // Uses relationships stored in `self`.
+    fn find_path(&self, from: &GraphName, to: &GraphName) -> Option<Vec<(String, bool)>> {
+        if !from.has_name() || !to.has_name() {
+            return None;
+        }
+        let from_name = from.name().unwrap();
+        let to_name = to.name().unwrap();
+
+        // Find a shortest path using BFS.
+        let mut predecessor: BTreeMap<String, (String, bool)> = BTreeMap::new();
+        predecessor.insert(from_name.clone(), (String::new(), false));
+        let mut queue: VecDeque<String> = VecDeque::new();
+        queue.push_back(from_name.clone());
+        while let Some(curr) = queue.pop_front() {
+            if curr == *to_name {
+                break;
+            }
+            // Prioritize subgraph relationships.
+            if let Some(neighbors) = self.subgraph.get(&curr) {
+                for next in neighbors {
+                    if !predecessor.contains_key(next) {
+                        predecessor.insert(next.clone(), (curr.clone(), false));
+                        queue.push_back(next.clone());
+                    }
+                }
+            }
+            // Then consider translation relationships.
+            if let Some(neighbors) = self.translation.get(&curr) {
+                for next in neighbors {
+                    if !predecessor.contains_key(next) {
+                        predecessor.insert(next.clone(), (curr.clone(), true));
+                        queue.push_back(next.clone());
+                    }
+                }
+            }
+        }
+        if !predecessor.contains_key(to_name) {
+            return None;
+        }
+
+        // Trace back the path.
+        let mut result: Vec<(String, bool)> = Vec::new();
+        result.push((from_name.clone(), false));
+        let (mut curr, mut is_translation) = predecessor.get(to_name).unwrap().clone();
+        while !curr.is_empty() {
+            result.push((curr.clone(), is_translation));
+            (curr, is_translation) = predecessor.get(&curr).unwrap().clone();
+        }
+        result.reverse();
+
+        Some(result)
+    }
+
+    /// Returns `true` if this graph is a subgraph of the given graph.
+    ///
+    /// Uses relationships stored in both graphs.
+    pub fn is_subgraph_of(&self, other: &GraphName) -> bool {
+        let mut merged = self.clone();
+        merged.add_relationships(other);
+        merged.find_subgraph_path(self, other).is_some()
+    }
+
+    /// Returns `true` if coordinates in this graph can be translated to coordinates in the given graph.
+    ///
+    /// Uses relationships stored in both graphs.
+    pub fn translates_to(&self, other: &GraphName) -> bool {
+        let mut merged = self.clone();
+        merged.add_relationships(other);
+        merged.find_path(self, other).is_some()
+    }
+
+    fn append_description(result: &mut String, num: usize, description: &str) {
+        let line = format!("Name {} is for {}\n", num, description);
+        result.push_str(&line); 
+    }
+
+    fn append_relationship(result: &mut String, step: usize, is_translation: bool) {
+        let relation = if is_translation {
+            "translates to"
+        } else {
+            "is a subgraph of"
+        };
+        let line = format!("Graph {} {} graph {}\n", step, relation, step + 1);
+        result.push_str(&line);
+    }
+
+    fn append_graph(result: &mut String, num: usize, name: &str) {
+        let line = format!("{}\t{}\n", num, name);
+        result.push_str(&line);
+    }
+
+    /// Returns a description of the relationship between this graph and the given graph.
+    ///
+    /// Uses relationships stored in both graphs.
+    /// The description consists of multiple lines and ends with a newline.
+    ///
+    /// # Arguments
+    ///
+    /// * `other`: Name of the other graph.
+    /// * `self_desc`: Description of this graph to use in the output.
+    /// * `other_desc`: Description of the other graph to use in the output.
+    pub fn describe_relationship(&self, other: &GraphName, self_desc: &str, other_desc: &str) -> String {
+        let mut merged = self.clone();
+        merged.add_relationships(other);
+
+        let no_name = String::from("(no name)");
+        let mut from = (self.name.as_ref().unwrap_or(&no_name).clone(), String::from(self_desc));
+        let mut to = (other.name.as_ref().unwrap_or(&no_name).clone(), String::from(other_desc));
+        let mut path = merged.find_path(self, other);
+        if path.is_none() {
+            std::mem::swap(&mut from, &mut to);
+            path = merged.find_path(other, self);
+        }
+
+        // Graph descriptions and relationships.
+        let mut result = String::new();
+        Self::append_description(&mut result, 1, &from.1);
+        if let Some(path) = &path {
+            for i in 1..path.len() {
+                Self::append_relationship(&mut result, i, path[i - 1].1);
+            }
+            Self::append_description(&mut result, path.len(), &to.1);
+        } else {
+            Self::append_description(&mut result, 2, &to.1);
+        }
+
+        // Graph names.
+        result.push_str("With graph names:\n");
+        if let Some(path) = path {
+            for (i, (name, _)) in path.iter().enumerate() {
+                Self::append_graph(&mut result, i + 1, name);
+            }
+        } else {
+            Self::append_graph(&mut result, 1, &from.0);
+            Self::append_graph(&mut result, 2, &to.0);
+        }
+
+        result
+    }
+}
+
+//-----------------------------------------------------------------------------

--- a/src/name/tests.rs
+++ b/src/name/tests.rs
@@ -1,0 +1,388 @@
+use super::*;
+
+//-----------------------------------------------------------------------------
+
+const NAME: &str = "A";
+const SUBGRAPH: &[(&str, &str)] = &[
+    ("A", "B"),
+    ("C", "D"),
+    ("D", "E"),
+];
+const TRANSLATION: &[(&str, &str)] = &[
+    ("B", "C"),
+    ("C", "F"),
+];
+
+fn manual() -> GraphName {
+    let mut name = GraphName::new(String::from(NAME));
+    for (subgraph, supergraph) in SUBGRAPH.iter() {
+        name.add_subgraph(subgraph, supergraph);
+    }
+    for (from, to) in TRANSLATION.iter() {
+        name.add_translation(from, to);
+    }
+    name
+}
+
+fn from_parents() -> GraphName {
+    let f = GraphName::new(String::from("F"));
+    let e = GraphName::new(String::from("E"));
+    let mut d = GraphName::new(String::from("D"));
+    d.make_subgraph_of(&e);
+    let mut c = GraphName::new(String::from("C"));
+    c.make_subgraph_of(&d);
+    c.add_translation_to(&f);
+    let mut b = GraphName::new(String::from("B"));
+    b.add_translation_to(&c);
+    let mut a = GraphName::new(String::from(NAME));
+    a.make_subgraph_of(&b);
+    a
+}
+
+// In the following functions, the first returned value also contains fields (e.g. tags, rows)
+// unrelated to GraphName, while the second only contains those derived from GraphName.
+
+fn tags() -> (Tags, Tags) {
+    let mut all_tags = Tags::new();
+    let mut name_tags = Tags::new();
+    all_tags.insert(crate::SOURCE_KEY, crate::SOURCE_VALUE);
+    all_tags.insert(GraphName::TAG_NAME, NAME);
+    name_tags.insert(GraphName::TAG_NAME, NAME);
+
+    let mut subgraph_value = String::new();
+    for (subgraph, supergraph) in SUBGRAPH.iter() {
+        if !subgraph_value.is_empty() {
+            subgraph_value.push(GraphName::TAG_RELATIONSHIP_LIST_SEPARATOR);
+        }
+        subgraph_value.push_str(subgraph);
+        subgraph_value.push(GraphName::TAG_GFA_RELATIONSHIP_SEPARATOR);
+        subgraph_value.push_str(supergraph);
+    }
+    all_tags.insert(GraphName::TAG_SUBGRAPH, &subgraph_value);
+    name_tags.insert(GraphName::TAG_SUBGRAPH, &subgraph_value);
+
+    let mut translation_value = String::new();
+    for (from, to) in TRANSLATION.iter() {
+        if !translation_value.is_empty() {
+            translation_value.push(GraphName::TAG_RELATIONSHIP_LIST_SEPARATOR);
+        }
+        translation_value.push_str(from);
+        translation_value.push(GraphName::TAG_GFA_RELATIONSHIP_SEPARATOR);
+        translation_value.push_str(to);
+    }
+    all_tags.insert(GraphName::TAG_TRANSLATION, &translation_value);
+    name_tags.insert(GraphName::TAG_TRANSLATION, &translation_value);
+
+    (all_tags, name_tags)
+}
+
+fn gfa_header_lines() -> (Vec<String>, Vec<String>) {
+    let mut all_lines = Vec::new();
+    all_lines.push(String::from("H\tVN:Z:1.1"));
+    all_lines.push(format!("H\t{}:Z:{}", GraphName::GFA_HEADER_NAME, NAME));
+
+    for (subgraph, supergraph) in SUBGRAPH.iter() {
+        all_lines.push(format!(
+            "H\t{}:Z:{}{}{}",
+            GraphName::GFA_GAF_HEADER_SUBGRAPH,
+            subgraph,
+            GraphName::TAG_GFA_RELATIONSHIP_SEPARATOR,
+            supergraph
+        ));
+    }
+
+    for (from, to) in TRANSLATION.iter() {
+        all_lines.push(format!(
+            "H\t{}:Z:{}{}{}",
+            GraphName::GFA_GAF_HEADER_TRANSLATION,
+            from,
+            GraphName::TAG_GFA_RELATIONSHIP_SEPARATOR,
+            to
+        ));
+    }
+
+    let name_lines: Vec<String> = all_lines.iter().skip(1).cloned().collect();
+    (all_lines, name_lines)
+}
+
+fn gaf_header_lines() -> (Vec<String>, Vec<String>) {
+    let mut all_lines = Vec::new();
+    all_lines.push(String::from("@HD\tVN:Z:1.0"));
+    all_lines.push(format!("@{}\t{}", GraphName::GAF_HEADER_NAME, NAME));
+
+    for (subgraph, supergraph) in SUBGRAPH.iter() {
+        all_lines.push(format!(
+            "@{}\t{}\t{}",
+            GraphName::GFA_GAF_HEADER_SUBGRAPH,
+            subgraph,
+            supergraph
+        ));
+    }
+
+    for (from, to) in TRANSLATION.iter() {
+        all_lines.push(format!(
+            "@{}\t{}\t{}",
+            GraphName::GFA_GAF_HEADER_TRANSLATION,
+            from,
+            to
+        ));
+    }
+
+    let name_lines: Vec<String> = all_lines.iter().skip(1).cloned().collect();
+    (all_lines, name_lines)
+}
+
+fn expected_description_lines(steps: usize, has_path: bool) -> usize {
+    let mut lines = 2; // Descriptions of both names.
+    lines += steps; // One line per step.
+    lines += 1; // With graph names.
+    lines += steps + 1; // One line per graph.
+    if !has_path {
+        lines += 1; // Final graph.
+    }
+    lines
+}
+
+fn test_describe_relationship(from: &GraphName, to: &GraphName, from_desc: &str, to_desc: &str, steps: usize, has_path: bool) {
+    let description = from.describe_relationship(to, from_desc, to_desc);
+    let expected_lines = expected_description_lines(steps, has_path);
+    let description_lines: Vec<&str> = description.lines().collect();
+    let from_name = from.name().cloned().unwrap_or(String::from("<no name>"));
+    let to_name = to.name().cloned().unwrap_or(String::from("<no name>"));
+    assert_eq!(description_lines.len(), expected_lines, "Unexpected number of description lines for {} and {}", from_name, to_name);
+}
+
+#[test]
+fn graph_name_empty() {
+    let default = GraphName::default();
+    assert!(!default.has_name(), "Expected has_name() to be false in default GraphName");
+    assert!(default.name().is_none(), "Expected no name in default GraphName");
+
+    let empty_tags = Tags::new();
+    let from_tags = GraphName::from_tags(&empty_tags);
+    assert!(from_tags.is_ok(), "Failed to build GraphName from empty tags: {}", from_tags.unwrap_err());
+    let from_tags = from_tags.unwrap();
+    assert!(!from_tags.has_name(), "Expected has_name() to be false in GraphName built from empty tags");
+    assert!(from_tags.name().is_none(), "Expected no name in GraphName built from empty tags");
+    assert!(!from_tags.is_same(&default), "GraphNames with missing names should not be the same");
+    let mut to_tags = Tags::new();
+    default.set_tags(&mut to_tags);
+    assert_eq!(to_tags, empty_tags, "Expected no tags to be written from default GraphName");
+    test_describe_relationship(&default, &from_tags, "default", "from_tags", 0, false);
+
+    let empty_header_lines = Vec::new();
+    let from_headers = GraphName::from_header_lines(&empty_header_lines);
+    assert!(from_headers.is_ok(), "Failed to build GraphName from empty header lines: {}", from_headers.unwrap_err());
+    let from_headers = from_headers.unwrap();
+    assert!(!from_headers.has_name(), "Expected has_name() to be false in GraphName built from empty header lines");
+    assert!(from_headers.name().is_none(), "Expected no name in GraphName built from empty header lines");
+    assert!(!from_headers.is_same(&default), "GraphNames with missing names should not be the same");
+    test_describe_relationship(&default, &from_headers, "default", "from_headers", 0, false);
+    let gfa_headers = default.to_gfa_header_lines();
+    assert!(gfa_headers.is_empty(), "Expected no GFA header lines from default GraphName");
+    let gaf_headers = default.to_gaf_header_lines();
+    assert!(gaf_headers.is_empty(), "Expected no GAF header lines from default GraphName");
+}
+
+#[test]
+fn graph_name_manual() {
+    let manual = manual();
+    let from_parents = from_parents();
+    assert!(manual.is_same(&from_parents), "GraphName built manually does not match GraphName built from parents");
+    assert_eq!(manual, from_parents, "GraphName built manually is not equal to GraphName built from parents");
+
+    let subgraph: Vec<(&str, &str)> = manual.subgraph_iter().collect();
+    assert_eq!(subgraph.len(), SUBGRAPH.len(), "Wrong number of subgraph relationships from iterator");
+    for (i, pair) in subgraph.iter().enumerate() {
+        assert_eq!(*pair, SUBGRAPH[i], "Wrong subgraph relationship {} from iterator", i);
+    }
+
+    let translation: Vec<(&str, &str)> = manual.translation_iter().collect();
+    assert_eq!(translation.len(), TRANSLATION.len(), "Wrong number of translation relationships from iterator");
+    for (i, pair) in translation.iter().enumerate() {
+        assert_eq!(*pair, TRANSLATION[i], "Wrong translation relationship {} from iterator", i);
+    }
+}
+
+#[test]
+fn graph_name_tags() {
+    let (all_tags, name_tags) = tags();
+    let from_tags = GraphName::from_tags(&all_tags);
+    assert!(from_tags.is_ok(), "Failed to build GraphName from tags: {}", from_tags.unwrap_err());
+    let from_tags = from_tags.unwrap();
+    assert!(from_tags.has_name(), "GraphName built from tags should have a name");
+    assert_eq!(from_tags.name().unwrap(), NAME, "Wrong name in GraphName built from tags");
+
+    let from_manual = manual();
+    assert!(from_tags.is_same(&from_manual), "GraphName built from tags does not match manual GraphName");
+    assert_eq!(from_tags, from_manual, "GraphName built from tags is not equal to manual GraphName");
+
+    let mut to_tags = Tags::new();
+    from_tags.set_tags(&mut to_tags);
+    assert_eq!(to_tags, name_tags, "Tags written from GraphName do not match expected tags");
+
+    let empty_name = GraphName::default();
+    empty_name.set_tags(&mut to_tags);
+    assert!(!to_tags.contains_key(GraphName::TAG_NAME), "Graph name tag was not cleared");
+    assert!(!to_tags.contains_key(GraphName::TAG_SUBGRAPH), "Subgraph tag was not cleared");
+    assert!(!to_tags.contains_key(GraphName::TAG_TRANSLATION), "Translation tag was not cleared");
+}
+
+#[test]
+fn graph_name_gfa() {
+    let (all_headers, name_headers) = gfa_header_lines();
+    let from_headers = GraphName::from_header_lines(&all_headers);
+    assert!(from_headers.is_ok(), "Failed to build GraphName from GFA header lines: {}", from_headers.unwrap_err());
+    let from_headers = from_headers.unwrap();
+    assert!(from_headers.has_name(), "GraphName built from GFA header lines should have a name");
+    assert_eq!(from_headers.name().unwrap(), NAME, "Wrong name in GraphName built from GFA header lines");
+
+    let from_manual = manual();
+    assert!(from_headers.is_same(&from_manual), "GraphName built from GFA header lines does not match manual GraphName");
+    assert_eq!(from_headers, from_manual, "GraphName built from GFA header lines is not equal to manual GraphName");
+
+    let to_headers = from_headers.to_gfa_header_lines();
+    assert_eq!(to_headers, name_headers, "GFA header lines written from GraphName do not match expected header lines");
+}
+
+#[test]
+fn graph_name_gaf() {
+    let (all_headers, name_headers) = gaf_header_lines();
+    let from_headers = GraphName::from_header_lines(&all_headers);
+    assert!(from_headers.is_ok(), "Failed to build GraphName from GAF header lines: {}", from_headers.unwrap_err());
+    let from_headers = from_headers.unwrap();
+    assert!(from_headers.has_name(), "GraphName built from GAF header lines should have a name");
+    assert_eq!(from_headers.name().unwrap(), NAME, "Wrong name in GraphName built from GAF header lines");
+
+    let from_manual = manual();
+    assert!(from_headers.is_same(&from_manual), "GraphName built from GAF header lines does not match manual GraphName");
+    assert_eq!(from_headers, from_manual, "GraphName built from GAF header lines is not equal to manual GraphName");
+
+    let to_headers = from_headers.to_gaf_header_lines();
+    assert_eq!(to_headers, name_headers, "GAF header lines written from GraphName do not match expected header lines");
+}
+
+#[test]
+fn graph_name_subgraph() {
+    let a = manual();
+    let a_empty = GraphName::new(String::from(NAME));
+
+    // Same graph.
+    assert!(a.is_subgraph_of(&a_empty), "Graph is not a subgrap of itself (relationships in subgraph)");
+    assert!(a_empty.is_subgraph_of(&a), "Graph is not a subgrap of itself (relationships in supergraph)");
+    assert!(a_empty.is_subgraph_of(&a_empty), "Graph is not a subgrap of itself (no relationships)");
+    test_describe_relationship(&a, &a_empty, "original", "same", 0, true);
+
+    // Single step.
+    {
+        let b_empty = GraphName::new(String::from("B"));
+        let mut b = b_empty.clone();
+        b.add_relationships(&a);
+        assert!(a.is_subgraph_of(&b_empty), "A is not a subgraph of B (relationships in subgraph)");
+        assert!(a_empty.is_subgraph_of(&b), "A is not a subgraph of B (relationships in supergraph)");
+        assert!(!b.is_subgraph_of(&a), "B is a subgraph of A");
+        test_describe_relationship(&a, &b, "subgraph (first)", "supergraph (second)", 1, true);
+        test_describe_relationship(&b, &a, "supergraph (first)", "subgraph (second)", 1, true);
+    }
+
+    // No path.
+    let c_empty = GraphName::new(String::from("C"));
+    let mut c = c_empty.clone();
+    c.add_relationships(&a);
+    assert!(!a.is_subgraph_of(&c), "A is a subgraph of C");
+    assert!(!c.is_subgraph_of(&a), "C is a subgraph of A");
+    // Skip description test, as there is a path with a translation.
+
+    // Multiple steps.
+    {
+        let e_empty = GraphName::new(String::from("E"));
+        let mut e = e_empty.clone();
+        e.add_relationships(&a);
+        assert!(c.is_subgraph_of(&e_empty), "C is not a subgraph of E (relationships in subgraph)");
+        assert!(c_empty.is_subgraph_of(&e), "C is not a subgraph of E (relationships in supergraph)");
+        assert!(!e.is_subgraph_of(&c), "E is a subgraph of C");
+        test_describe_relationship(&c, &e, "subgraph", "supergraph", 2, true);
+    }
+
+    // Relationships split between graphs.
+    {
+        let mut from = GraphName::new(String::from("from"));
+        from.add_subgraph("from", "middle");
+        let mut to = GraphName::new(String::from("to"));
+        to.add_subgraph("middle", "to");
+        assert!(from.is_subgraph_of(&to), "from is not a subgraph of to");
+        assert!(!to.is_subgraph_of(&from), "to is a subgraph of from");
+        test_describe_relationship(&from, &to, "from", "to", 2, true);
+    }
+}
+
+#[test]
+fn graph_name_translation() {
+    let a = manual();
+    let a_empty = GraphName::new(String::from(NAME));
+
+    // Same graph.
+    assert!(a.translates_to(&a_empty), "Graph does not translate to itself (relationships in source)");
+    assert!(a_empty.translates_to(&a), "Graph does not translate to itself (relationships in target)");
+    assert!(a_empty.translates_to(&a_empty), "Graph does not translate to itself (no relationships)");
+    test_describe_relationship(&a, &a_empty, "original", "same", 0, true);
+
+    // Single subgraph step.
+    let b_empty = GraphName::new(String::from("B"));
+    let mut b = b_empty.clone();
+    b.add_relationships(&a);
+    assert!(a.translates_to(&b_empty), "A does not translate to B (relationships in source)");
+    assert!(a_empty.translates_to(&b), "A does not translate to B (relationships in target)");
+    assert!(!b.translates_to(&a), "B translates to A");
+    test_describe_relationship(&a, &b, "source", "target", 1, true);
+
+    // Single translation step.
+    let c_empty = GraphName::new(String::from("C"));
+    let mut c = c_empty.clone();
+    c.add_relationships(&a);
+    assert!(b.translates_to(&c_empty), "B does not translate to C (relationships in source)");
+    assert!(b_empty.translates_to(&c), "B does not translate to C (relationships in target)");
+    assert!(!c.translates_to(&b), "C translates to B");
+    test_describe_relationship(&b, &c, "source", "target", 1, true);
+
+    // Mixed steps.
+    assert!(a.translates_to(&c_empty), "A does not translate to C (relationships in source)");
+    assert!(a_empty.translates_to(&c), "A does not translate to C (relationships in target)");
+    assert!(!c.translates_to(&a), "C translates to A");
+    test_describe_relationship(&a, &c, "source", "target", 2, true);
+
+    // Multiple subgraph steps.
+    {
+        let e_empty = GraphName::new(String::from("E"));
+        let mut e = e_empty.clone();
+        e.add_relationships(&a);
+        assert!(c.translates_to(&e_empty), "C does not translate to E (relationships in source)");
+        assert!(c_empty.translates_to(&e), "C does not translate to E (relationships in target)");
+        assert!(!e.translates_to(&c), "E translates to C");
+        test_describe_relationship(&c, &e, "source", "target", 2, true);
+    }
+
+    // Multiple translation steps.
+    {
+        let f_empty = GraphName::new(String::from("F"));
+        let mut f = f_empty.clone();
+        f.add_relationships(&a);
+        assert!(b.translates_to(&f_empty), "B does not translate to F (relationships in source)");
+        assert!(b_empty.translates_to(&f), "B does not translate to F (relationships in target)");
+        assert!(!f.translates_to(&b), "F translates to B");
+        test_describe_relationship(&b, &f, "source", "target", 2, true);
+    }
+
+    // Relationships split between graphs.
+    {
+        let mut from = GraphName::new(String::from("from"));
+        from.add_translation("from", "middle");
+        let mut to = GraphName::new(String::from("to"));
+        to.add_translation("middle", "to");
+        assert!(from.translates_to(&to), "from does not translate to to");
+        assert!(!to.translates_to(&from), "to translates to from");
+        test_describe_relationship(&from, &to, "source", "target", 2, true);
+    }
+}
+
+//-----------------------------------------------------------------------------

--- a/src/support.rs
+++ b/src/support.rs
@@ -1074,7 +1074,7 @@ impl AsRef<StringArray> for Dictionary {
 /// # Examples
 ///
 /// ```
-/// use gbz::support::Tags;
+/// use gbz::Tags;
 ///
 /// let mut tags = Tags::new();
 /// tags.insert("first-key", "first-value");


### PR DESCRIPTION
Imports the `GraphName` structure from [pggname](https://github.com/jltsiren/pggname). The graph name and relationship information stored in `Tags` and GFA/GAF headers is no longer tied to the pggname scheme, but it can also be used with other potential schemes. As a consequence, `gbunzip` can now include this information in GFA headers.