### PR TITLE
Use safe SparseBuilder::set in From<BWTBuilder> for BWT

### DIFF
--- a/src/bwt.rs
+++ b/src/bwt.rs
@@ -328,7 +328,7 @@ impl From<BWTBuilder> for BWT {
     fn from(source: BWTBuilder) -> Self {
         let mut builder = SparseBuilder::new(source.encoder.len(), source.offsets.len()).unwrap();
         for offset in source.offsets.iter() {
-            unsafe { builder.set_unchecked(*offset); }
+            builder.set(*offset);
         }
         BWT {
             index: SparseVector::try_from(builder).unwrap(),


### PR DESCRIPTION
In `From<BWTBuilder> for BWT`, `source.offsets` are inserted into `builder` using `builder.set_unchecked(*offset)`.

Since `From<BWTBuilder> for BWT` is only called during BWT construction/conversion and is not in a performance-critical query loop, using the safe `builder.set(*offset)` is preferable to eliminate an unnecessary `unsafe` block.